### PR TITLE
[PREVIEW] Add in missing Solicitor fields and required data type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -425,5 +425,68 @@ public class CoreCaseData extends AosCaseData {
 
     @JsonProperty("AosLetterHolderId")
     private String aosLetterHolderId;
+
+    @JsonProperty("solApplicationFeeOrderSummary")
+    private OrderSummary orderSummary;
+
+    @JsonProperty("SolicitorFeeAccountNumber")
+    private String solicitorFeeAccountNumber;
+
+    @JsonProperty("D8SelectedDivorceCentreSiteId")
+    private String d8SelectedDivorceCentreSiteId;
+
+    @JsonProperty("PetitionerSolicitorFirm")
+    private String petitionerSolicitorFirm;
+
+    @JsonProperty("PetitionerSolicitorPhone")
+    private String petitionerSolicitorPhone;
+
+    @JsonProperty("PetitionerSolicitorName")
+    private String petitionerSolicitorName;
+
+    @JsonProperty("DerivedPetitionerSolicitorAddr")
+    private String derivedPetitionerSolicitorAddr;
+
+    @JsonProperty("PetitionerSolicitorEmail")
+    private String petitionerSolicitorEmail;
+
+    @JsonProperty("SolicitorAgreeToReceiveEmails")
+    private String solicitorAgreeToReceiveEmails;
+
+    @JsonProperty("SolStatementOfReconciliationCertify")
+    private String solStatementOfReconciliationCertify;
+
+    @JsonProperty("SolStatementOfReconciliationDiscussed")
+    private String solStatementOfReconciliationDiscussed;
+
+    @JsonProperty("StatementOfReconciliationComments")
+    private String statementOfReconciliationComments;
+
+    @JsonProperty("SolStatementOfReconciliationName")
+    private String solStatementOfReconciliationName;
+
+    @JsonProperty("SolStatementOfReconciliationFirm")
+    private String solStatementOfReconciliationFirm;
+
+    @JsonProperty("SolPaymentHowToPay")
+    private String solPaymentHowToPay;
+
+    @JsonProperty("solSignStatementofTruth")
+    private String solSignStatementofTruth;
+
+    @JsonProperty("RespNameDifferentToMarriageCertExplain")
+    private String respNameDifferentToMarriageCertExplain;
+
+    @JsonProperty("PetitionerSolicitorToEffectService")
+    private String petitionerSolicitorToEffectService;
+
+    @JsonProperty("SolClaimCostsDetails")
+    private String solClaimCostsDetails;
+
+    @JsonProperty("SeparationLivedTogetherAsCoupleAgain")
+    private String separationLivedTogetherAsCoupleAgain;
+
+    @JsonProperty("SeparationLivedTogetherAsCoupleAgainDetails")
+    private String separationLivedTogetherAsCoupleAgainDetails;
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeItem.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class FeeItem {
+
+    @JsonProperty("value")
+    private FeeValue value;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeItem.java
@@ -8,6 +8,9 @@ import lombok.ToString;
 @ToString
 public class FeeItem {
 
+    @JsonProperty("id")
+    private String id;
+
     @JsonProperty("value")
     private FeeValue value;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeResponse.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiModel(description = "The response from retrieving a fee from fees and payments service")
+@Builder
+public class FeeResponse {
+    @ApiModelProperty(value = "The fee identifier")
+    private String feeCode;
+    @ApiModelProperty(value = "The fee amount in pounds")
+    private Double amount;
+    @ApiModelProperty(value = "The fee version")
+    private Integer version;
+    @ApiModelProperty(value = "The fee description")
+    private String description;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/FeeValue.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class FeeValue {
+
+    @JsonProperty("FeeDescription")
+    private String feeDescription;
+
+    @JsonProperty("FeeVersion")
+    private String feeVersion;
+
+    @JsonProperty("FeeCode")
+    private String feeCode;
+
+    @JsonProperty("FeeAmount")
+    private String feeAmount;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/OrderSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/OrderSummary.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OrderSummary {
+
+    @JsonProperty("PaymentReference")
+    private String paymentReference;
+
+    @JsonProperty("PaymentTotal")
+    private String paymentTotal;
+
+    @JsonProperty("Fees")
+    private List<FeeItem> fees;
+
+    public void add(FeeResponse... fees) {
+        NumberFormat formatter = new DecimalFormat("#0");
+        List<FeeItem> feesItems = new ArrayList<>();
+        FeeValue value = new FeeValue();
+        FeeItem feeItem = new FeeItem();
+        for (FeeResponse fee : fees) {
+            if (fee != null) {
+                value.setFeeAmount(String.valueOf(formatter.format(fee.getAmount() * 100)));
+                value.setFeeCode(fee.getFeeCode());
+                value.setFeeDescription(fee.getDescription());
+                value.setFeeVersion(String.valueOf(fee.getVersion()));
+                feeItem.setValue(value);
+                feesItems.add(feeItem);
+            }
+        }
+        this.setFees(feesItems);
+        double sum = Arrays.asList(fees).stream().mapToDouble(FeeResponse::getAmount).sum() * 100;
+        this.setPaymentTotal(String.valueOf(formatter.format(sum)));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/OrderSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/OrderSummary.java
@@ -22,25 +22,4 @@ public class OrderSummary {
 
     @JsonProperty("Fees")
     private List<FeeItem> fees;
-
-    public void add(FeeResponse... fees) {
-        NumberFormat formatter = new DecimalFormat("#0");
-        List<FeeItem> feesItems = new ArrayList<>();
-        FeeValue value = new FeeValue();
-        FeeItem feeItem = new FeeItem();
-        for (FeeResponse fee : fees) {
-            if (fee != null) {
-                value.setFeeAmount(String.valueOf(formatter.format(fee.getAmount() * 100)));
-                value.setFeeCode(fee.getFeeCode());
-                value.setFeeDescription(fee.getDescription());
-                value.setFeeVersion(String.valueOf(fee.getVersion()));
-                feeItem.setValue(value);
-                feesItems.add(feeItem);
-            }
-        }
-        this.setFees(feesItems);
-        double sum = Arrays.asList(fees).stream().mapToDouble(FeeResponse::getAmount).sum() * 100;
-        this.setPaymentTotal(String.valueOf(formatter.format(sum)));
-    }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/AddDocumentsSolicitorITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/AddDocumentsSolicitorITest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.functionaltest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceApplication;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = CaseFormatterServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@AutoConfigureMockMvc
+public class AddDocumentsSolicitorITest {
+    private static final String API_URL = "/caseformatter/version/1/add-documents";
+    private static final String PAYLOAD_PATH = "fixtures/model/ccd/solicitorCaseDocumentsInput.json";
+    private static final String EXPECTED_PAYLOAD_PATH = "fixtures/model/ccd/solicitorCaseDocumentsOutput.json";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @Test
+    public void givenValidSolicitorDetails_whenAddDocuments_thenReturnExpected() throws Exception {
+        final CoreCaseData expectedCaseData =
+            (CoreCaseData)ObjectMapperTestUtil.jsonToObject(EXPECTED_PAYLOAD_PATH, CoreCaseData.class);
+
+        MvcResult result = webClient.perform(post(API_URL)
+            .content(ObjectMapperTestUtil.loadJson(PAYLOAD_PATH))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        final CoreCaseData actualCaseData =
+            (CoreCaseData)ObjectMapperTestUtil.jsonStringToObject(result.getResponse().getContentAsString(),
+                CoreCaseData.class);
+
+        assertThat(expectedCaseData, samePropertyValuesAs(actualCaseData));
+    }
+}

--- a/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsInput.json
+++ b/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsInput.json
@@ -1,0 +1,164 @@
+{
+    "documents":[
+        {
+            "url":"url1",
+            "documentType":"petition",
+            "fileName":"fileName1"
+        },
+        {
+            "url":"url2",
+            "documentType":"aos",
+            "fileName":"fileName2"
+        }
+    ],
+    "caseData":{
+        "PetitionerSolicitorEmail": "test-solicitor@example.com",
+        "D8DerivedRespondentHomeAddress": "Respondent\nHome\nAddress",
+        "D8PetitionerNameChangedHow": [
+            "marriageCertificate",
+            "deedPoll",
+            "other"
+        ],
+        "D8DerivedPetitionerHomeAddress": "Petitioner\nHome\nAddress",
+        "D8DivorceCostsClaim": "Yes",
+        "D8InferredRespondentGender": "female",
+        "FeeAccountReference": "Solicitor PBA",
+        "D8RespondentCorrespondenceSendToSol": "Yes",
+        "D8FinancialOrderFor": [
+            "petitioner",
+            "children"
+        ],
+        "solSignStatementofTruth": "Yes",
+        "SolStatementOfReconciliationName": "Test Solicitor",
+        "SolStatementOfReconciliationFirm": "Solicitor Firm",
+        "D8RespondentLastName": "Doe",
+        "D8PetitionerNameDifferentToMarriageCert": "Yes",
+        "D8JurisdictionConnection": [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G"
+        ],
+        "SolStatementOfReconciliationCertify": "Yes",
+        "D8LegalProceedingsDetails": "Other legal matters.",
+        "D8SelectedDivorceCentreSiteId": "AA01",
+        "D8PetitionerLastName": "Smith",
+        "D8SolicitorReference": "SolicitorReference",
+        "D8PetitionerPhoneNumber": "01234567890",
+        "D8StatementOfTruth": "Yes",
+        "PetitionerSolicitorFirm": "Test Firm",
+        "D8RespondentSolicitorCompany": "Solicitor Firm",
+        "SolStatementOfReconciliationDiscussed": "Yes",
+        "SolicitorAgreeToReceiveEmails": "Yes",
+        "D8PetitionerEmail": "petitioner-test-email@example.com",
+        "D8ReasonForDivorceBehaviourDetails": "Bad Behaviour from everybody.",
+        "SolClaimCostsDetails": "Claiming costs for everything.",
+        "D8DivorceUnit": "eastMidlands",
+        "D8MarriagePetitionerName": "John Smith",
+        "PetitionerSolicitorPhone": "01234567890",
+        "D8MarriageIsSameSexCouple": "No",
+        "D8FinancialOrder": "Yes",
+        "D8RespondentNameAsOnMarriageCertificate": "Yes",
+        "D8MarriageDate": "2000-01-01",
+        "SolPaymentHowToPay": "feePayByAccount",
+        "D8RespondentSolicitorName": "Respondent Solicitor",
+        "StatementOfReconciliationComments": "No comment.",
+        "D8RespondentFirstName": "Jane",
+        "D8DocumentsUploaded": [
+            {
+                "id": "40610c8b-4c9d-4b8d-b047-719631ba38b2",
+                "value": {
+                    "DocumentLink": {
+                        "document_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/bba741e7-cec8-42c2-bc69-465a01da3689",
+                        "document_filename": "PBAOrderSummary.png",
+                        "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/bba741e7-cec8-42c2-bc69-465a01da3689/binary"
+                    },
+                    "DocumentType": "marriageCert",
+                    "DocumentComment": "Some comment",
+                    "DocumentFileName": "PbaOrder",
+                    "DocumentDateAdded": "2018-01-01",
+                    "DocumentEmailContent": "Test Marriage Certificate"
+                }
+            }
+        ],
+        "RespNameDifferentToMarriageCertExplain": "Name Change Certificate",
+        "SolicitorFeeAccountNumber": "PBA0896366",
+        "DerivedPetitionerSolicitorAddr": "Test Firm\nTest Address\nTest Postcode",
+        "PetitionerSolicitorName": "Test Solicitor",
+        "D8MarriedInUk": "Yes",
+        "D8PetitionerFirstName": "John",
+        "D8MarriageRespondentName": "Jane Doe",
+        "D8PetitionerContactDetailsConfidential": "share",
+        "D8DerivedRespondentSolicitorAddr": "Solicitor Firm\nAddress\nPostcode",
+        "D8LegalProceedings": "Yes",
+        "createdDate": "2018-09-27",
+        "PetitionerSolicitorToEffectService": "Yes",
+        "D8ReasonForDivorce": "unreasonable-behaviour",
+        "solApplicationFeeOrderSummary": {
+            "Fees": [
+                {
+                    "id": "816675f2-dd53-4950-8afa-7d4b164f0e34",
+                    "value": {
+                        "FeeCode": "FEE0002",
+                        "FeeAmount": "55000",
+                        "FeeVersion": "4",
+                        "FeeDescription": "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2."
+                    }
+                }
+            ],
+            "PaymentTotal": "55000",
+            "PaymentReference": null
+        },
+        "D8InferredPetitionerGender": "male"
+        "D8DocumentsGenerated":[
+            {
+                "id":null,
+                "value":{
+                    "DocumentType":"petition",
+                    "DocumentLink":{
+                        "document_url":"url1",
+                        "document_binary_url":"url1/binary",
+                        "document_filename":"fileName1.pdf"
+                    },
+                    "DocumentDateAdded":null,
+                    "DocumentComment":null,
+                    "DocumentFileName":"fileName1",
+                    "DocumentEmailContent":null
+                }
+            },
+            {
+                "id":null,
+                "value":{
+                    "DocumentType":"aos",
+                    "DocumentLink":{
+                        "document_url":"url2",
+                        "document_binary_url":"url2/binary",
+                        "document_filename":"fileName2.pdf"
+                    },
+                    "DocumentDateAdded":null,
+                    "DocumentComment":null,
+                    "DocumentFileName":"fileName2",
+                    "DocumentEmailContent":null
+                }
+            },
+            {
+                "id":null,
+                "value":{
+                    "DocumentType":"aos1",
+                    "DocumentLink":{
+                        "document_url":"url3",
+                        "document_binary_url":"url3/binary",
+                        "document_filename":"fileName3.pdf"
+                    },
+                    "DocumentDateAdded":null,
+                    "DocumentComment":null,
+                    "DocumentFileName":"fileName3",
+                    "DocumentEmailContent":null
+                }
+            }
+        ]
+    }
+}

--- a/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsInput.json
+++ b/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsInput.json
@@ -112,7 +112,7 @@
             "PaymentTotal": "55000",
             "PaymentReference": null
         },
-        "D8InferredPetitionerGender": "male"
+        "D8InferredPetitionerGender": "male",
         "D8DocumentsGenerated":[
             {
                 "id":null,

--- a/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsOutput.json
+++ b/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsOutput.json
@@ -1,0 +1,150 @@
+{
+    "PetitionerSolicitorEmail": "test-solicitor@example.com",
+    "D8DerivedRespondentHomeAddress": "Respondent\nHome\nAddress",
+    "D8PetitionerNameChangedHow": [
+        "marriageCertificate",
+        "deedPoll",
+        "other"
+    ],
+    "D8DerivedPetitionerHomeAddress": "Petitioner\nHome\nAddress",
+    "D8DivorceCostsClaim": "Yes",
+    "D8InferredRespondentGender": "female",
+    "FeeAccountReference": "Solicitor PBA",
+    "D8RespondentCorrespondenceSendToSol": "Yes",
+    "D8FinancialOrderFor": [
+        "petitioner",
+        "children"
+    ],
+    "solSignStatementofTruth": "Yes",
+    "SolStatementOfReconciliationName": "Test Solicitor",
+    "SolStatementOfReconciliationFirm": "Solicitor Firm",
+    "D8RespondentLastName": "Doe",
+    "D8PetitionerNameDifferentToMarriageCert": "Yes",
+    "D8JurisdictionConnection": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F",
+        "G"
+    ],
+    "SolStatementOfReconciliationCertify": "Yes",
+    "D8LegalProceedingsDetails": "Other legal matters.",
+    "D8SelectedDivorceCentreSiteId": "AA01",
+    "D8PetitionerLastName": "Smith",
+    "D8SolicitorReference": "SolicitorReference",
+    "D8PetitionerPhoneNumber": "01234567890",
+    "D8StatementOfTruth": "Yes",
+    "PetitionerSolicitorFirm": "Test Firm",
+    "D8RespondentSolicitorCompany": "Solicitor Firm",
+    "SolStatementOfReconciliationDiscussed": "Yes",
+    "SolicitorAgreeToReceiveEmails": "Yes",
+    "D8PetitionerEmail": "petitioner-test-email@example.com",
+    "D8ReasonForDivorceBehaviourDetails": "Bad Behaviour from everybody.",
+    "SolClaimCostsDetails": "Claiming costs for everything.",
+    "D8DivorceUnit": "eastMidlands",
+    "D8MarriagePetitionerName": "John Smith",
+    "PetitionerSolicitorPhone": "01234567890",
+    "D8MarriageIsSameSexCouple": "No",
+    "D8FinancialOrder": "Yes",
+    "D8RespondentNameAsOnMarriageCertificate": "Yes",
+    "D8MarriageDate": "2000-01-01",
+    "SolPaymentHowToPay": "feePayByAccount",
+    "D8RespondentSolicitorName": "Respondent Solicitor",
+    "StatementOfReconciliationComments": "No comment.",
+    "D8RespondentFirstName": "Jane",
+    "D8DocumentsUploaded": [
+        {
+            "id": "40610c8b-4c9d-4b8d-b047-719631ba38b2",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/bba741e7-cec8-42c2-bc69-465a01da3689",
+                    "document_filename": "PBAOrderSummary.png",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/bba741e7-cec8-42c2-bc69-465a01da3689/binary"
+                },
+                "DocumentType": "marriageCert",
+                "DocumentComment": "Some comment",
+                "DocumentFileName": "PbaOrder",
+                "DocumentDateAdded": "2018-01-01",
+                "DocumentEmailContent": "Test Marriage Certificate"
+            }
+        }
+    ],
+    "RespNameDifferentToMarriageCertExplain": "Name Change Certificate",
+    "SolicitorFeeAccountNumber": "PBA0896366",
+    "DerivedPetitionerSolicitorAddr": "Test Firm\nTest Address\nTest Postcode",
+    "PetitionerSolicitorName": "Test Solicitor",
+    "D8MarriedInUk": "Yes",
+    "D8PetitionerFirstName": "John",
+    "D8MarriageRespondentName": "Jane Doe",
+    "D8PetitionerContactDetailsConfidential": "share",
+    "D8DerivedRespondentSolicitorAddr": "Solicitor Firm\nAddress\nPostcode",
+    "D8LegalProceedings": "Yes",
+    "createdDate": "2018-09-27",
+    "PetitionerSolicitorToEffectService": "Yes",
+    "D8ReasonForDivorce": "unreasonable-behaviour",
+    "solApplicationFeeOrderSummary": {
+        "Fees": [
+            {
+                "id": "816675f2-dd53-4950-8afa-7d4b164f0e34",
+                "value": {
+                    "FeeCode": "FEE0002",
+                    "FeeAmount": "55000",
+                    "FeeVersion": "4",
+                    "FeeDescription": "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2."
+                }
+            }
+        ],
+        "PaymentTotal": "55000",
+        "PaymentReference": null
+    },
+    "D8InferredPetitionerGender": "male"
+    "D8DocumentsGenerated":[
+        {
+            "id":null,
+            "value":{
+                "DocumentType":"petition",
+                "DocumentLink":{
+                    "document_url":"url1",
+                    "document_binary_url":"url1/binary",
+                    "document_filename":"fileName1.pdf"
+                },
+                "DocumentDateAdded":null,
+                "DocumentComment":null,
+                "DocumentFileName":"fileName1",
+                "DocumentEmailContent":null
+            }
+        },
+        {
+            "id":null,
+            "value":{
+                "DocumentType":"aos",
+                "DocumentLink":{
+                    "document_url":"url2",
+                    "document_binary_url":"url2/binary",
+                    "document_filename":"fileName2.pdf"
+                },
+                "DocumentDateAdded":null,
+                "DocumentComment":null,
+                "DocumentFileName":"fileName2",
+                "DocumentEmailContent":null
+            }
+        },
+        {
+            "id":null,
+            "value":{
+                "DocumentType":"aos1",
+                "DocumentLink":{
+                    "document_url":"url3",
+                    "document_binary_url":"url3/binary",
+                    "document_filename":"fileName3.pdf"
+                },
+                "DocumentDateAdded":null,
+                "DocumentComment":null,
+                "DocumentFileName":"fileName3",
+                "DocumentEmailContent":null
+            }
+        }
+    ]
+}

--- a/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsOutput.json
+++ b/src/test/resources/fixtures/model/ccd/solicitorCaseDocumentsOutput.json
@@ -99,7 +99,7 @@
         "PaymentTotal": "55000",
         "PaymentReference": null
     },
-    "D8InferredPetitionerGender": "male"
+    "D8InferredPetitionerGender": "male",
     "D8DocumentsGenerated":[
         {
             "id":null,


### PR DESCRIPTION
Missing solicitor fields meant that when a caseworker issued a Solicitor case, the Solicitor details were lost, as on issue the formatter is called. This adds in the missing fields and since they are JSON ignored, it shouldn't impact anything else. Also null fields are ignored when returned to the calling service.