### PR TITLE
[PREVIEW] DIV-3335 Fix Nullpointer error on empty respondentHomeAddress

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -450,7 +450,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapRespondentHomeAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getRespondentHomeAddress())) {
+        if (Objects.nonNull(divorceSession.getRespondentHomeAddress())
+            && Objects.nonNull(divorceSession.getRespondentHomeAddress().getAddressField())) {
             result.setD8DerivedRespondentHomeAddress(
                 join(LINE_SEPARATOR, divorceSession.getRespondentHomeAddress().getAddressField()));
         }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AddressesCaseToCCDMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AddressesCaseToCCDMapperUTest.java
@@ -41,4 +41,22 @@ public class AddressesCaseToCCDMapperUTest {
 
         assertThat(actualCoreCaseData, samePropertyValuesAs(expectedCoreCaseData));
     }
+
+    @Test
+    public void givenNullRespondentHomeAddress_whenTransformDivorceDataToCCD_thenReturnEmptyAddress()
+        throws URISyntaxException, IOException {
+
+        CoreCaseData expectedCoreCaseData = (CoreCaseData) ObjectMapperTestUtil
+            .jsonToObject("fixtures/divorcetoccdmapping/ccd/empty-respondent-home-addresscase.json",
+                CoreCaseData.class);
+        expectedCoreCaseData.setCreatedDate(LocalDate.now().format(ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = (DivorceSession) ObjectMapperTestUtil
+            .jsonToObject("fixtures/divorcetoccdmapping/divorce/respondent-home-addresses-empty.json",
+                DivorceSession.class);
+
+        CoreCaseData actualCoreCaseData = mapper.divorceCaseDataToCourtCaseData(divorceSession);
+
+        assertThat(actualCoreCaseData, samePropertyValuesAs(expectedCoreCaseData));
+    }
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/empty-respondent-home-addresscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/empty-respondent-home-addresscase.json
@@ -1,0 +1,12 @@
+{
+    "D8RespondentHomeAddress" : {
+        "AddressLine1" : null,
+        "AddressLine2" : null,
+        "AddressLine3" : null,
+        "PostTown" : null,
+        "PostCode" : null,
+        "County" : null,
+        "Country" : null
+    },
+    "D8Cohort" : "onlineSubmissionPrivateBeta"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/respondent-home-addresses-empty.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/respondent-home-addresses-empty.json
@@ -1,0 +1,5 @@
+{
+  "respondentHomeAddress": {
+    "addressType": "manual"
+  }
+}


### PR DESCRIPTION
# Description

DIV-3335 Fix Nullpointer error when  respondentHomeAddress has only AddressType attribute filled. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
