### PR TITLE
Allow derived fields mapping to be nullable

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivor
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
+import java.util.Optional;
+
 import static org.apache.commons.lang3.StringUtils.join;
 
 @Component
@@ -11,16 +13,21 @@ public class AdulteryStrategy implements ReasonForDivorceStrategy {
     private static final String ADULTERY = "adultery";
     private static final String LINE_SEPARATOR = "\n";
     private static final String YES = "Yes";
+    private static final String EMPTY_STRING = "";
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
         String derivedStatementOfCase = "";
 
-        if (divorceSession.getReasonForDivorceAdulteryKnowWhere().equals(YES)) {
+        if (Optional.ofNullable(
+            divorceSession.getReasonForDivorceAdulteryKnowWhere()).orElse(EMPTY_STRING).equals(YES)
+        ) {
             derivedStatementOfCase = join(divorceSession.getReasonForDivorceAdulteryWhereDetails(), LINE_SEPARATOR);
         }
 
-        if (divorceSession.getReasonForDivorceAdulteryKnowWhen().equals(YES)) {
+        if (Optional.ofNullable(
+            divorceSession.getReasonForDivorceAdulteryKnowWhen()).orElse(EMPTY_STRING).equals(YES)
+        ) {
             derivedStatementOfCase = join(derivedStatementOfCase,
                 divorceSession.getReasonForDivorceAdulteryWhenDetails(), LINE_SEPARATOR);
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
@@ -13,21 +13,16 @@ public class AdulteryStrategy implements ReasonForDivorceStrategy {
     private static final String ADULTERY = "adultery";
     private static final String LINE_SEPARATOR = "\n";
     private static final String YES = "Yes";
-    private static final String EMPTY_STRING = "";
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
         String derivedStatementOfCase = "";
 
-        if (Optional.ofNullable(
-            divorceSession.getReasonForDivorceAdulteryKnowWhere()).orElse(EMPTY_STRING).equals(YES)
-        ) {
+        if (YES.equals(divorceSession.getReasonForDivorceAdulteryKnowWhere())) {
             derivedStatementOfCase = join(divorceSession.getReasonForDivorceAdulteryWhereDetails(), LINE_SEPARATOR);
         }
 
-        if (Optional.ofNullable(
-            divorceSession.getReasonForDivorceAdulteryKnowWhen()).orElse(EMPTY_STRING).equals(YES)
-        ) {
+        if (YES.equals(divorceSession.getReasonForDivorceAdulteryKnowWhen())) {
             derivedStatementOfCase = join(derivedStatementOfCase,
                 divorceSession.getReasonForDivorceAdulteryWhenDetails(), LINE_SEPARATOR);
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategy.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivor
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
-import java.util.Optional;
-
 import static org.apache.commons.lang3.StringUtils.join;
 
 @Component

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategy.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
+import java.util.Date;
+import java.util.Optional;
+
 import static org.apache.commons.lang3.StringUtils.join;
 
 @Component
@@ -17,7 +20,8 @@ public class DesertionStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettyDesertionDate = DateFormatUtils.format(divorceSession.getReasonForDivorceDesertionDate(),
+        String prettyDesertionDate = DateFormatUtils.format(
+            Optional.ofNullable(divorceSession.getReasonForDivorceDesertionDate()).orElse(new Date(0)),
             "dd MMMM yyyy");
 
         String derivedStatementOfCase = String.format(DESERTION_STRING, divorceSession.getDivorceWho(),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategy.java
@@ -1,11 +1,8 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorce;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
-
-import java.util.Date;
-import java.util.Optional;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.util.DateUtil;
 
 import static org.apache.commons.lang3.StringUtils.join;
 
@@ -20,9 +17,9 @@ public class DesertionStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettyDesertionDate = DateFormatUtils.format(
-            Optional.ofNullable(divorceSession.getReasonForDivorceDesertionDate()).orElse(new Date(0)),
-            "dd MMMM yyyy");
+        String prettyDesertionDate = DateUtil.format(
+            divorceSession.getReasonForDivorceDesertionDate(), "dd MMMM yyyy"
+        );
 
         String derivedStatementOfCase = String.format(DESERTION_STRING, divorceSession.getDivorceWho(),
             prettyDesertionDate);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategy.java
@@ -1,11 +1,8 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorce;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
-
-import java.util.Date;
-import java.util.Optional;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.util.DateUtil;
 
 @Component
 public class SeparationFiveYearsStrategy implements ReasonForDivorceStrategy {
@@ -16,9 +13,9 @@ public class SeparationFiveYearsStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettySeparationDate = DateFormatUtils.format(
-            Optional.ofNullable(divorceSession.getReasonForDivorceSeperationDate()).orElse(new Date(0)),
-            "dd MMMM yyyy");
+        String prettySeparationDate = DateUtil.format(
+            divorceSession.getReasonForDivorceSeperationDate(), "dd MMMM yyyy"
+        );
 
         return String.format(SEPARATION_STRING, divorceSession.getDivorceWho(), prettySeparationDate);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategy.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
+import java.util.Date;
+import java.util.Optional;
+
 @Component
 public class SeparationFiveYearsStrategy implements ReasonForDivorceStrategy {
 
@@ -13,7 +16,8 @@ public class SeparationFiveYearsStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettySeparationDate = DateFormatUtils.format(divorceSession.getReasonForDivorceSeperationDate(),
+        String prettySeparationDate = DateFormatUtils.format(
+            Optional.ofNullable(divorceSession.getReasonForDivorceSeperationDate()).orElse(new Date(0)),
             "dd MMMM yyyy");
 
         return String.format(SEPARATION_STRING, divorceSession.getDivorceWho(), prettySeparationDate);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategy.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
+import java.util.Date;
+import java.util.Optional;
+
 @Component
 public class SeparationTwoYearsStrategy implements ReasonForDivorceStrategy {
 
@@ -13,7 +16,8 @@ public class SeparationTwoYearsStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettySeparationDate = DateFormatUtils.format(divorceSession.getReasonForDivorceSeperationDate(),
+        String prettySeparationDate = DateFormatUtils.format(
+            Optional.ofNullable(divorceSession.getReasonForDivorceSeperationDate()).orElse(new Date(0)),
             "dd MMMM yyyy");
 
         return String.format(SEPARATION_STRING, divorceSession.getDivorceWho(), prettySeparationDate);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategy.java
@@ -1,11 +1,8 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorce;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
-
-import java.util.Date;
-import java.util.Optional;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.util.DateUtil;
 
 @Component
 public class SeparationTwoYearsStrategy implements ReasonForDivorceStrategy {
@@ -16,9 +13,9 @@ public class SeparationTwoYearsStrategy implements ReasonForDivorceStrategy {
 
     @Override
     public String deriveStatementOfCase(DivorceSession divorceSession) {
-        String prettySeparationDate = DateFormatUtils.format(
-            Optional.ofNullable(divorceSession.getReasonForDivorceSeperationDate()).orElse(new Date(0)),
-            "dd MMMM yyyy");
+        String prettySeparationDate = DateUtil.format(
+            divorceSession.getReasonForDivorceSeperationDate(), "dd MMMM yyyy"
+        );
 
         return String.format(SEPARATION_STRING, divorceSession.getDivorceWho(), prettySeparationDate);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/util/DateUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/util/DateUtil.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.util;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import java.util.Date;
+import java.util.Optional;
+
+public class DateUtil {
+
+    public static String format(Date date, String pattern) {
+        return DateFormatUtils.format(
+            Optional.ofNullable(date).orElse(new Date(0)),
+            pattern
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/AdulteryStrategyUTest.java
@@ -70,4 +70,14 @@ public class AdulteryStrategyUTest {
 
         assertThat(derivedStatementOfCase, equalTo("On a washing machine.\nSome time ago.\nIt hurts inside."));
     }
+
+    @Test
+    public void testAdulteryWithNullValuesShouldNotThrowException() {
+        final DivorceSession divorceSession = new DivorceSession();
+        divorceSession.setReasonForDivorce(ADULTERY);
+
+        final String derivedStatementOfCase = adulteryStrategy.deriveStatementOfCase(divorceSession);
+
+        assertThat(derivedStatementOfCase, equalTo(""));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/DesertionStrategyUTest.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,5 +30,16 @@ public class DesertionStrategyUTest {
 
         assertThat(derivedStatementOfCase, equalTo(
             "I have been deserted by my husband on the 01 February 2015.\nHe told me that he is going to his mother."));
+    }
+
+    @Test
+    public void testDesertionWithNullValuesShouldNotThrowException() {
+        final DivorceSession divorceSession = new DivorceSession();
+        divorceSession.setReasonForDivorce(DESERTION);
+
+        final String derivedStatementOfCase = desertionStrategy.deriveStatementOfCase(divorceSession);
+
+        assertThat(derivedStatementOfCase, equalTo(
+            "I have been deserted by my null on the 01 January 1970.\n"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationFiveYearsStrategyUTest.java
@@ -28,4 +28,15 @@ public class SeparationFiveYearsStrategyUTest {
         assertThat(derivedStatementOfCase,
             equalTo("I have been separated from my wife for 5 years or more from the 01 January 2015."));
     }
+
+    @Test
+    public void testSeparationFiveYearsWithNullValuesShouldNotThrowException() {
+        final DivorceSession divorceSession = new DivorceSession();
+        divorceSession.setReasonForDivorce(SEPARATION_FIVE_YEARS);
+
+        final String derivedStatementOfCase = separationFiveYearsStrategy.deriveStatementOfCase(divorceSession);
+
+        assertThat(derivedStatementOfCase, equalTo(
+            "I have been separated from my null for 5 years or more from the 01 January 1970."));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/reasonfordivorce/SeparationTwoYearsStrategyUTest.java
@@ -28,4 +28,15 @@ public class SeparationTwoYearsStrategyUTest {
         assertThat(derivedStatementOfCase,
             equalTo("I have been separated from my husband for 2 years or more from the 01 January 2015."));
     }
+
+    @Test
+    public void testSeparationTwoYearsWithNullValuesShouldNotThrowException() {
+        final DivorceSession divorceSession = new DivorceSession();
+        divorceSession.setReasonForDivorce(SEPARATION_TWO_YEARS);
+
+        final String derivedStatementOfCase = separationTwoYearsStrategy.deriveStatementOfCase(divorceSession);
+
+        assertThat(derivedStatementOfCase, equalTo(
+            "I have been separated from my null for 2 years or more from the 01 January 1970."));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/util/DateUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/util/DateUtilUTest.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.util;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateUtilUTest {
+
+    @Test
+    public void nonNullDateReturnsFormattedDateString() {
+        assertEquals("01 01 2001", DateUtil.format(
+            Date.from(LocalDate.of(2001, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()),
+            "dd MM yyyy")
+        );
+    }
+
+    @Test
+    public void nullDateReturnsFormattedZeroDateString() {
+        assertEquals("01 01 1970", DateUtil.format(
+            null,
+            "dd MM yyyy")
+        );
+    }
+}


### PR DESCRIPTION
Due to the new draft retrieval format of converting to CCD first then DivorceSession and then returning to frontend, its possible to attempt mapping of partial data to CCD format.

This can cause NullPointerExceptions in certain scenarios, mainly around the derived field mapping.
As derived fields are being removed, this fix will just convert to Optionals and set default values if they don't exist.

We probably should raise a story removing non address derived field mappings soon as I don't believe they are in use or required now,