### PR TITLE
Added in missing solicitor fields and fix null address scenarios

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -41,6 +41,8 @@
     "D8RespondentFirstName": "Jane",
     "D8RespondentLastName": "Jamed",
     "D8DerivedRespondentCurrentName": "Jane Jamed",
+    "D8RespondentSolicitorName": "Justin",
+    "D8RespondentSolicitorCompany": "Case",
     "D8DerivedRespondentSolicitorDetails": "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress": {
         "AddressLine1": null,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -100,6 +100,8 @@ public abstract class DivorceCaseToCCDMapper {
         expression =
             "java(java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")))")
     @Mapping(source = "d8Documents", target = "d8Documents")
+    @Mapping(source = "respondentSolicitorName", target = "d8RespondentSolicitorName")
+    @Mapping(source = "respondentSolicitorCompany", target = "d8RespondentSolicitorCompany")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 
     private String translateToStringYesNo(final String value) {
@@ -434,7 +436,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapPetitionerHomeAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getPetitionerHomeAddress())) {
+        if (Objects.nonNull(divorceSession.getPetitionerHomeAddress())
+            && Objects.nonNull(divorceSession.getPetitionerHomeAddress().getAddressField())) {
             result.setD8DerivedPetitionerHomeAddress(
                 join(LINE_SEPARATOR, divorceSession.getPetitionerHomeAddress().getAddressField()));
         }
@@ -443,7 +446,8 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapPetitionerCorrespondenceAddress(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getPetitionerCorrespondenceAddress())) {
+        if (Objects.nonNull(divorceSession.getPetitionerCorrespondenceAddress())
+            && Objects.nonNull(divorceSession.getPetitionerCorrespondenceAddress().getAddressField())) {
             result.setD8DerivedPetitionerCorrespondenceAddress(
                 join(LINE_SEPARATOR, divorceSession.getPetitionerCorrespondenceAddress().getAddressField()));
         }
@@ -461,7 +465,8 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapRespondentCorrespondenceAddress(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getRespondentCorrespondenceAddress())) {
+        if (Objects.nonNull(divorceSession.getRespondentCorrespondenceAddress())
+            && Objects.nonNull(divorceSession.getRespondentCorrespondenceAddress().getAddressField())) {
             result.setD8DerivedRespondentCorrespondenceAddr(
                 join(LINE_SEPARATOR, divorceSession.getRespondentCorrespondenceAddress().getAddressField()));
         }
@@ -513,7 +518,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapRespondentSolicitorAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getRespondentSolicitorAddress())) {
+        if (Objects.nonNull(divorceSession.getRespondentSolicitorAddress())
+            && Objects.nonNull(divorceSession.getRespondentSolicitorAddress().getAddressField())) {
             result.setD8DerivedRespondentSolicitorAddr(
                 join(LINE_SEPARATOR, divorceSession.getRespondentSolicitorAddress().getAddressField()));
         }
@@ -522,8 +528,11 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapDerivedRespondentSolicitorDetails(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getRespondentSolicitorName())) {
-            String solicitorAddress = join(LINE_SEPARATOR,
+        if (Objects.nonNull(divorceSession.getRespondentSolicitorName())
+            && Objects.nonNull(divorceSession.getRespondentSolicitorAddress())
+            && Objects.nonNull(divorceSession.getRespondentSolicitorAddress().getAddressField())) {
+
+            String solicitorAddress = solicitorAddress = join(LINE_SEPARATOR,
                 divorceSession.getRespondentSolicitorAddress().getAddressField());
 
             String solictorDetails = join(LINE_SEPARATOR, Arrays.asList(divorceSession.getRespondentSolicitorName(),
@@ -543,7 +552,8 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapDerivedLivingArrangementsLastLivedAddr(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getLivingArrangementsLastLivedTogetherAddress())) {
+        if (Objects.nonNull(divorceSession.getLivingArrangementsLastLivedTogetherAddress())
+            && Objects.nonNull(divorceSession.getLivingArrangementsLastLivedTogetherAddress().getAddressField())) {
             result.setD8DerivedLivingArrangementsLastLivedAddr(join(LINE_SEPARATOR,
                 divorceSession.getLivingArrangementsLastLivedTogetherAddress().getAddressField()));
         }
@@ -564,7 +574,8 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapDerivedReasonForDivorceAdultery3rdAddr(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
-        if (Objects.nonNull(divorceSession.getReasonForDivorceAdultery3rdAddress())) {
+        if (Objects.nonNull(divorceSession.getReasonForDivorceAdultery3rdAddress())
+            && Objects.nonNull(divorceSession.getReasonForDivorceAdultery3rdAddress().getAddressField())) {
             result.setD8DerivedReasonForDivorceAdultery3rdAddr(
                 join(LINE_SEPARATOR, divorceSession.getReasonForDivorceAdultery3rdAddress().getAddressField()));
         }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AddressesNullFieldsCaseToCCDMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AddressesNullFieldsCaseToCCDMapperUTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.divorcetoccdformat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceApplication;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.DivorceCaseToCCDMapper;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = CaseFormatterServiceApplication.class)
+public class AddressesNullFieldsCaseToCCDMapperUTest {
+
+    @Autowired
+    private DivorceCaseToCCDMapper mapper;
+
+    @Test
+    public void shouldMapAllAndTransformAllFieldsForAddressWithNullValuesMappingScenario()
+        throws URISyntaxException, IOException {
+
+        CoreCaseData expectedCoreCaseData = (CoreCaseData) ObjectMapperTestUtil
+            .jsonToObject("fixtures/divorcetoccdmapping/ccd/nulladdressfields.json", CoreCaseData.class);
+        expectedCoreCaseData.setCreatedDate(LocalDate.now().format(ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = (DivorceSession) ObjectMapperTestUtil
+            .jsonToObject("fixtures/divorcetoccdmapping/divorce/null-address-fields.json", DivorceSession.class);
+
+        CoreCaseData actualCoreCaseData = mapper.divorceCaseDataToCourtCaseData(divorceSession);
+
+        assertThat(actualCoreCaseData, samePropertyValuesAs(expectedCoreCaseData));
+    }
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/nulladdressfields.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/nulladdressfields.json
@@ -25,31 +25,31 @@
     "D8PetitionerNameChangedHowOtherDetails" : null,
     "D8PetitionerContactDetailsConfidential" : "share",
     "D8PetitionerHomeAddress" : {
-      "County" : null,
-      "PostCode" : "SW9 9PE"
+        "County" : null,
+        "PostCode" : null
     },
-    "D8DerivedPetitionerHomeAddress" : "82 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedPetitionerHomeAddress" : null,
     "D8PetitionerCorrespondenceAddress" : {
-      "County" : null,
-      "PostCode" : "AB24 232"
+        "County" : null,
+        "PostCode" : null
     },
-    "D8DerivedPetitionerCorrespondenceAddr" : "84 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedPetitionerCorrespondenceAddr" : null,
     "D8PetitionerCorrespondenceUseHomeAddress" : "NO",
     "D8RespondentNameAsOnMarriageCertificate" : null,
     "D8RespondentFirstName" : "Jane",
     "D8RespondentLastName" : "Jamed",
     "D8DerivedRespondentCurrentName" : "Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails" : "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedRespondentSolicitorDetails" : null,
     "D8RespondentHomeAddress" : {
-      "County" : null,
-      "PostCode" : "SS SSS"
+        "County" : null,
+        "PostCode" : null
     },
-    "D8DerivedRespondentHomeAddress" : "88 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedRespondentHomeAddress" : null,
     "D8RespondentCorrespondenceAddress" : {
-      "County" : null,
-      "PostCode" : "SW9 9PE"
+        "County" : null,
+        "PostCode" : null
     },
-    "D8DerivedRespondentCorrespondenceAddr" : "82 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedRespondentCorrespondenceAddr" : null,
     "D8RespondentSolicitorName" : "Justin",
     "D8RespondentSolicitorCompany" : "Case",
     "D8RespondentCorrespondenceSendToSol" : null,
@@ -66,7 +66,7 @@
         "AddressLine2":null,
         "AddressLine3":null,
         "PostTown":null,
-        "PostCode":"AB22 222",
+        "PostCode":null,
         "County":null,
         "Country":null
     },
@@ -92,7 +92,7 @@
     "D8ReasonForDivorceAdulteryIsNamed" : "NO",
     "D8ReasonForDivorceAdultery3rdAddress" : {
         "County" : null,
-        "PostCode" : "A AAA"
+        "PostCode" : null
     },
     "D8FinancialOrder" : "YES",
     "D8FinancialOrderFor" : [ "petitioner", "children" ],
@@ -114,36 +114,36 @@
     "D8ResidualJurisdictionEligible" : null,
     "Payments" : null,
     "D8DocumentsUploaded" : [
-      {
-        "id" : null,
-        "value" : {
-          "DocumentType" : "other",
-          "DocumentLink" : {
-            "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
-            "document_binary_url" : null,
-            "document_filename" : null
-          },
-          "DocumentDateAdded" : "2017-12-11",
-          "DocumentComment" : "",
-          "DocumentFileName" : "govuklogo.png",
-          "DocumentEmailContent" : ""
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "govuklogo.png",
+                "DocumentEmailContent" : ""
+            }
+        },
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType": "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded": "2017-12-11",
+                "DocumentComment": "",
+                "DocumentFileName": "d8-eng.pdf",
+                "DocumentEmailContent": ""
+            }
         }
-      },
-      {
-        "id" : null,
-        "value" : {
-          "DocumentType": "other",
-          "DocumentLink" : {
-            "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683",
-            "document_binary_url" : null,
-            "document_filename" : null
-          },
-          "DocumentDateAdded": "2017-12-11",
-          "DocumentComment": "",
-          "DocumentFileName": "d8-eng.pdf",
-          "DocumentEmailContent": ""
-        }
-      }
     ],
     "D8RejectDocumentsUploaded" : null,
     "D8StatementOfTruth" : null,
@@ -174,16 +174,16 @@
     "D8ReasonForDivorceSeperationMonth" : null,
     "D8ReasonForDivorceSeperationYear" : null,
     "D8DerivedReasonForDivorceAdultery3dPtyNm" : null,
-    "D8DerivedRespondentSolicitorAddr" : "90 Landor Road\nLondon\nSW9 9PE",
-    "D8DerivedLivingArrangementsLastLivedAddr" : "Flat A-B\n86 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedRespondentSolicitorAddr" : null,
+    "D8DerivedLivingArrangementsLastLivedAddr" : null,
     "D8Connections" : {
-      "A" : "The Petitioner and the Respondent are habitually resident in England and Wales",
-      "B" : null,
-      "C" : "The Respondent is habitually resident in England and Wales",
-      "D" : null,
-      "E" : null,
-      "F" : null,
-      "G" : null
+        "A" : "The Petitioner and the Respondent are habitually resident in England and Wales",
+        "B" : null,
+        "C" : "The Respondent is habitually resident in England and Wales",
+        "D" : null,
+        "E" : null,
+        "F" : null,
+        "G" : null
     },
     "D8DocumentsGenerated" : null,
     "D8ConnectionSummary" : null,
@@ -193,9 +193,9 @@
     "D8ReasonForDivorceSeperation" : null,
     "D8ReasonForDivorceSeperationBeforeMarria" : null,
     "D8ReasonForDivorceDesertion" : null,
-    "D8DerivedReasonForDivorceAdultery3rdAddr" : "90 Landor Road\nLondon\nSW9 9PE",
+    "D8DerivedReasonForDivorceAdultery3rdAddr" : null,
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
     "D8PetitionerConsent" : "YES"
-  }
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/null-address-fields.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/null-address-fields.json
@@ -1,12 +1,4 @@
 {
-    "cookie": {
-        "originalMaxAge": null,
-        "expires": null,
-        "secure": false,
-        "httpOnly": true,
-        "path": "/"
-    },
-    "expires": 1507919805739,
     "screenHasMarriageBroken": "Yes",
     "screenHasRespondentAddress": "Yes",
     "screenHasMarriageCert": "Yes",

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/null-address-fields.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/null-address-fields.json
@@ -1,0 +1,217 @@
+{
+    "cookie": {
+        "originalMaxAge": null,
+        "expires": null,
+        "secure": false,
+        "httpOnly": true,
+        "path": "/"
+    },
+    "expires": 1507919805739,
+    "screenHasMarriageBroken": "Yes",
+    "screenHasRespondentAddress": "Yes",
+    "screenHasMarriageCert": "Yes",
+    "screenHasPrinter": "Yes",
+    "helpWithFeesNeedHelp": "Yes",
+    "helpWithFeesAppliedForFees": "Yes",
+    "helpWithFeesReferenceNumber": "HWF-123-456",
+    "divorceWho": "husband",
+    "marriageIsSameSexCouple": "No",
+    "marriageDateDay": 2,
+    "marriageDateMonth": 2,
+    "marriageDateYear": 2001,
+    "marriageDate": "2001-02-02T00:00:00.000Z",
+    "marriageCanDivorce": true,
+    "marriageDateIsFuture": false,
+    "marriageDateMoreThan100": false,
+    "marriageWhereMarried": "england",
+    "jurisdictionPath": [
+        "JurisdictionHabitualResidence",
+        "JurisdictionInterstitial"
+    ],
+    "petitionerContactDetailsConfidential": "share",
+    "petitionerFirstName": "John",
+    "petitionerLastName": "Smith",
+    "respondentFirstName": "Jane",
+    "respondentLastName": "Jamed",
+    "marriagePetitionerName": "John Doe",
+    "marriageRespondentName": "Jenny Benny",
+    "petitionerNameDifferentToMarriageCertificate": "Yes",
+    "petitionerNameChangedHow": [
+        "marriageCertificate"
+    ],
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
+    "petitionerPhoneNumber": "01234567890",
+    "petitionerHomeAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "petitionerCorrespondenceUseHomeAddress": "No",
+    "livingArrangementsLiveTogether": "No",
+    "respondentCorrespondenceUseHomeAddress": "Solicitor",
+    "reasonForDivorce": "unreasonable-behaviour",
+    "reasonForDivorceHasMarriageDate": true,
+    "reasonForDivorceShowAdultery": true,
+    "reasonForDivorceShowUnreasonableBehaviour": true,
+    "reasonForDivorceShowTwoYearsSeparation": true,
+    "reasonForDivorceShowFiveYearsSeparation": true,
+    "reasonForDivorceShowDesertion": true,
+    "reasonForDivorceLimitReasons": false,
+    "reasonForDivorceEnableAdultery": true,
+    "reasonForDivorceBehaviourDetails": [
+        "My wife is having an affair this week."
+    ],
+    "legalProceedings": "Yes",
+    "legalProceedingsRelated": [
+        "children"
+    ],
+    "legalProceedingsDetails": "The legal proceeding details",
+    "financialOrder": "Yes",
+    "financialOrderFor": [
+        "petitioner",
+        "children"
+    ],
+    "claimsCosts": "Yes",
+    "reasonForDivorceAdulteryIsNamed": "No",
+    "claimsCostsFrom": [
+        "respondent"
+    ],
+    "claimsCostsAppliedForFees": true,
+    "reasonForDivorceClaiming5YearSeparation": false,
+    "reasonForDivorceClaimingAdultery": false,
+    "marriageCertificateFiles": [
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "govuklogo.png",
+            "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+            "mimeType" : "image/png",
+            "status" : "OK"
+        },
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "d8-eng.pdf",
+            "fileUrl" : "https://api-gateway.test.dm.reform.hmcts.net/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683",
+            "mimeType" : "application/pdf",
+            "status" : "OK"
+        }
+    ],
+    "court": {
+        "eastMidlands": {
+            "phone": "0115 955 8266",
+            "divorceCentre": "East Midlands Regional Divorce Centre",
+            "courtCity": "Nottingham",
+            "poBox": "PO Box 10447",
+            "postCode": "NG2 9QN",
+            "openingHours": "Telephone Enquiries from: 8am to 4pm",
+            "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber": "0115 955 8186"
+        },
+        "westMidlands": {
+            "divorceCentre": "West Midlands Regional Divorce Centre",
+            "courtCity": "Stoke-on-Trent",
+            "poBox": "PO Box 3650",
+            "postCode": "ST4 9NH",
+            "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+            "phoneNumber": "0300 123 5577"
+        },
+        "southWest": {
+            "divorceCentre": "South West Regional Divorce Centre",
+            "courtCity": "Southampton",
+            "poBox": "PO Box 1792",
+            "postCode": "SO15 9GG",
+            "openingHours": "Telephone Enquiries from: 8am to 4pm",
+            "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+            "phoneNumber": "023 8038 4200"
+        }
+    },
+    "courts": "eastMidlands",
+    "jurisdictionConnection": [
+        "A",
+        "C"
+    ],
+    "connections": {
+        "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+        "C": "The Respondent is habitually resident in England and Wales"
+    },
+    "jurisdictionPetitionerResidence": "Yes",
+    "jurisdictionRespondentResidence": "Yes",
+    "jurisdictionConfidentLegal": "Yes",
+    "jurisdictionConnectionFirst": "A",
+    "respondentCorrespondenceAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "petitionerCorrespondenceAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "livingArrangementsLastLivedTogether": "No",
+    "livingArrangementsLastLivedTogetherAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "respondentLivesAtLastAddress": "No",
+    "respondentHomeAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "respondentSolicitorName": "Justin",
+    "respondentSolicitorCompany": "Case",
+    "respondentSolicitorAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "reasonForDivorceAdultery3rdAddress": {
+        "addressType": null,
+        "postcode": null,
+        "address": null,
+        "addressConfirmed": null,
+        "validPostcode": null,
+        "postcodeError": null,
+        "url": null,
+        "formattedAddress": null
+    },
+    "petitionerConsent" : "Yes",
+    "sessionKey": "4d3750ad58d94896a0042b4ad4ac8e3ec3aca0723826a81c7adc6dcd1ddee5a1:9cc8a76688bde61315e40e5e13866078:85bc7a64fe2f7ee61e3a086d70b910cb03d60c308dfecf42bae1d63bb0850eca7060fd7c0b4c14dfaacb45679d8bc8287b1ae85718e75b137a2d0386f784e952"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/nullfields.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/nullfields.json
@@ -132,7 +132,6 @@
   "jurisdictionConnectionFirst": "A",
   "livingArrangementsLastLivedTogether": "No",
   "respondentLivesAtLastAddress": "No",
-  "respondentSolicitorCompany": "Case",
   "petitionerConsent" : "Yes",
   "sessionKey": "4d3750ad58d94896a0042b4ad4ac8e3ec3aca0723826a81c7adc6dcd1ddee5a1:9cc8a76688bde61315e40e5e13866078:85bc7a64fe2f7ee61e3a086d70b910cb03d60c308dfecf42bae1d63bb0850eca7060fd7c0b4c14dfaacb45679d8bc8287b1ae85718e75b137a2d0386f784e952"
 }


### PR DESCRIPTION
SolicitorName and SolicitorFirm were not being mapped.
Also Address fields with null values could cause an NPE when mapping the address to derived address format.
This also checks the null value of that particular field.