### PR TITLE
(Don't merge) DIV-3719 - added mapping for dueDate from Divorce to CCD format

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -172,5 +172,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "dueDate": "2018-11-20"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
@@ -301,5 +301,6 @@
     }
   },
   "petitionerConsent" : "Yes",
+  "dueDate": "2018-11-20",
   "sessionKey": "4d3750ad58d94896a0042b4ad4ac8e3ec3aca0723826a81c7adc6dcd1ddee5a1:9cc8a76688bde61315e40e5e13866078:85bc7a64fe2f7ee61e3a086d70b910cb03d60c308dfecf42bae1d63bb0850eca7060fd7c0b4c14dfaacb45679d8bc8287b1ae85718e75b137a2d0386f784e952"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -110,6 +110,7 @@ public abstract class DivorceCaseToCCDMapper {
         target = "reasonForDivorceDecisionDate")
     @Mapping(source = "reasonForDivorceLivingApartDate", dateFormat = SIMPLE_DATE_FORMAT,
         target = "reasonForDivorceLivingApartDate")
+    @Mapping(source = "dueDate", dateFormat = SIMPLE_DATE_FORMAT, target = "dueDate")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 
     private String translateToStringYesNo(final String value) {

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -197,5 +197,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "dueDate": "2018-11-20"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
@@ -290,5 +290,6 @@
     }
   },
   "petitionerConsent" : "Yes",
+  "dueDate": "2018-11-20",
   "sessionKey": "4d3750ad58d94896a0042b4ad4ac8e3ec3aca0723826a81c7adc6dcd1ddee5a1:9cc8a76688bde61315e40e5e13866078:85bc7a64fe2f7ee61e3a086d70b910cb03d60c308dfecf42bae1d63bb0850eca7060fd7c0b4c14dfaacb45679d8bc8287b1ae85718e75b137a2d0386f784e952"
 }


### PR DESCRIPTION
# Description

Added `dueDate` to the Divorce -> CCD mapper so that it's retained.
 
Fixes #DIV-3719

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
