### PR TITLE
Change ExistingPayment update logic to replace existing payments only

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
@@ -94,7 +94,7 @@
     "D8JurisdictionRespondentResidence": "YES",
     "Payments": [
         {
-            "id": null,
+            "id": "123456789",
             "value": {
                 "PaymentChannel": "card",
                 "PaymentTransactionId": "111222333",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/payment/PaymentCollection.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/payment/PaymentCollection.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class PaymentCollection {
     private String id;
     private Payment value;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
@@ -18,16 +18,7 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
         List<PaymentCollection> updatedPayments = new ArrayList<>();
 
         existingPayments.stream()
-            .forEach(payment -> {
-                if (payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
-                    updatedPayments.add(PaymentCollection.builder()
-                        .id(payment.getId())
-                        .value(newPayment)
-                        .build());
-                } else {
-                    updatedPayments.add(payment);
-                }
-            });
+            .forEach(payment -> updatedPayments.add(getUpdatedPayment(payment, newPayment)));
 
         return updatedPayments;
     }
@@ -37,5 +28,13 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
         return Objects.nonNull(existingPayments) && existingPayments.stream()
             .anyMatch(
                 payment -> payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference()));
+    }
+
+    private PaymentCollection getUpdatedPayment(PaymentCollection existingPayment, Payment newPayment) {
+        if (existingPayment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
+            return existingPayment.toBuilder().value(newPayment).build();
+        }
+
+        return existingPayment;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Payment;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.PaymentCollection;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -15,12 +14,9 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
     @Override
     public List<PaymentCollection> getCurrentPaymentsList(Payment newPayment,
                                                           List<PaymentCollection> existingPayments) {
-        List<PaymentCollection> updatedPayments = new ArrayList<>();
-
-        existingPayments.stream()
-            .forEach(payment -> updatedPayments.add(getUpdatedPayment(payment, newPayment)));
-
-        return updatedPayments;
+        return existingPayments.stream()
+            .map(payment -> mapExistingPayment(payment, newPayment))
+            .collect(Collectors.toList());
     }
 
     @Override
@@ -30,7 +26,7 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
                 payment -> payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference()));
     }
 
-    private PaymentCollection getUpdatedPayment(PaymentCollection existingPayment, Payment newPayment) {
+    private PaymentCollection mapExistingPayment(PaymentCollection existingPayment, Payment newPayment) {
         if (existingPayment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
             return existingPayment.toBuilder().value(newPayment).build();
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Pay
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Component
 public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
@@ -13,10 +14,9 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
     @Override
     public List<PaymentCollection> getCurrentPaymentsList(Payment newPayment,
                                                           List<PaymentCollection> existingPayments) {
-        existingPayments.removeIf(
-            payment -> payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference()));
-
-        existingPayments.add(PaymentCollection.builder().value(newPayment).build());
+        existingPayments.stream()
+            .map(payment -> mapExistingPayment(payment, newPayment))
+            .collect(Collectors.toList());
 
         return existingPayments;
     }
@@ -28,4 +28,11 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
                 payment -> payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference()));
     }
 
+    private PaymentCollection mapExistingPayment(PaymentCollection existingPayment, Payment newPayment) {
+        if (existingPayment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
+            existingPayment.setValue(newPayment);
+        }
+
+        return existingPayment;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Payment;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.PaymentCollection;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -14,11 +15,21 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
     @Override
     public List<PaymentCollection> getCurrentPaymentsList(Payment newPayment,
                                                           List<PaymentCollection> existingPayments) {
-        existingPayments.stream()
-            .map(payment -> mapExistingPayment(payment, newPayment))
-            .collect(Collectors.toList());
+        List<PaymentCollection> updatedPayments = new ArrayList<>();
 
-        return existingPayments;
+        existingPayments.stream()
+            .forEach(payment -> {
+                if (payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
+                    updatedPayments.add(PaymentCollection.builder()
+                        .id(payment.getId())
+                        .value(newPayment)
+                        .build());
+                } else {
+                    updatedPayments.add(payment);
+                }
+            });
+
+        return updatedPayments;
     }
 
     @Override
@@ -26,13 +37,5 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
         return Objects.nonNull(existingPayments) && existingPayments.stream()
             .anyMatch(
                 payment -> payment.getValue().getPaymentReference().equals(newPayment.getPaymentReference()));
-    }
-
-    private PaymentCollection mapExistingPayment(PaymentCollection existingPayment, Payment newPayment) {
-        if (existingPayment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
-            existingPayment.setValue(newPayment);
-        }
-
-        return existingPayment;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
@@ -17,26 +17,28 @@ public class ExistingPaymentReferenceStrategyUTest {
 
     @Test
     public void testExistingPaymentReferenceAndPaymentReferenceWillReplacePayment() {
-        final PaymentCollection newPayment = createPayment("111222333", "success");
-        final PaymentCollection existingPayment = createPayment("999888777", "success");
-        final PaymentCollection toBeReplacedPayment = createPayment("111222333", "created");
+        final PaymentCollection newPayment = createPayment("111222333", "success", "123456789");
+        final PaymentCollection existingPayment = createPayment("999888777", "success", "12345");
+        final PaymentCollection toBeReplacedPayment = createPayment("111222333", "created", "123");
 
         final List<PaymentCollection> existingPaymentsList = new ArrayList<>();
         existingPaymentsList.add(existingPayment);
         existingPaymentsList.add(toBeReplacedPayment);
 
-        final List<PaymentCollection> expectedPaymentsList = Arrays.asList(existingPayment, newPayment);
+        final PaymentCollection updatedNewPayment = createPayment("111222333", "success", "123");
+
+        final List<PaymentCollection> expectedPaymentsList = Arrays.asList(existingPayment, updatedNewPayment);
         final List<PaymentCollection> returnedPaymentsList = existingPaymentReferenceStrategy
             .getCurrentPaymentsList(newPayment.getValue(), existingPaymentsList);
 
         assertThat(returnedPaymentsList, equalTo(expectedPaymentsList));
     }
 
-    private PaymentCollection createPayment(String reference, String status) {
+    private PaymentCollection createPayment(String reference, String status, String collectionId) {
         final Payment payment = new Payment();
         payment.setPaymentReference(reference);
         payment.setPaymentStatus(status);
 
-        return PaymentCollection.builder().value(payment).build();
+        return PaymentCollection.builder().id(collectionId).value(payment).build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
@@ -5,9 +5,9 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Pay
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.PaymentCollection;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -27,7 +27,7 @@ public class ExistingPaymentReferenceStrategyUTest {
 
         final PaymentCollection updatedNewPayment = createPayment("111222333", "success", "123");
 
-        final List<PaymentCollection> expectedPaymentsList = Arrays.asList(existingPayment, updatedNewPayment);
+        final List<PaymentCollection> expectedPaymentsList = asList(existingPayment, updatedNewPayment);
         final List<PaymentCollection> returnedPaymentsList = existingPaymentReferenceStrategy
             .getCurrentPaymentsList(newPayment.getValue(), existingPaymentsList);
 

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
@@ -102,7 +102,7 @@
     "D8JurisdictionHabituallyResLast6Months" : null,
     "D8ResidualJurisdictionEligible" : null,
     "Payments" : [{
-        "id" : null,
+        "id" : "123456789",
         "value" : {
             "PaymentChannel" : "card",
             "PaymentTransactionId" : "111222333",


### PR DESCRIPTION
Due to CCD CRUD update on Collection Elements, our Payment code which removes existing references broke. We don't want to put Delete permissions on Payments, so this PR changes so that it only updates existing payments.

Assuming we don't get duplicate PaymentReference payments now. Even if there is, they will all be updated to the same values which should always be the latest Gov UK status.