### PR TITLE
Exclude code duplication check for the Mapper classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,9 +248,15 @@ def sonarExclusions = [
     '**uk/gov/hmcts/reform/divorce/caseformatterservice/CaseFormatterServiceApplication.java'
 ]
 
+def sonarCpdExclusions = [
+    '**uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java',
+    '**uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java'
+]
+
 sonarqube {
     properties {
         property "sonar.exclusions", sonarExclusions.join(", ")
+        property "sonar.cpd.exclusions", sonarCpdExclusions.join(", ")
         property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/apiTest.exec"
         property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
         property "sonar.projectKey", "DivorceCaseFormatterService"


### PR DESCRIPTION
This is to fix the sonar failing issue.
Sonar is reporting incorrectly that there is duplicate code block between CCDCaseToDivorceMapper and DivorceCaseToCCDMapper, when the code block in question is a reverse mapping.
This change just excludes the two classes from the duplicate code check.