### PR TITLE
Add respondent confidential back in

### DIFF
--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/additionalpayment.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/additionalpayment.json
@@ -182,5 +182,6 @@
     "D8InferredRespondentGender" : "male",
     "D8PetitionerConsent" : "YES",
     "IssueDate": "2006-02-02",
-    "dueDate":"2006-02-10"
+    "dueDate":"2006-02-10",
+    "RespondentContactDetailsConfidential": "keep"
 }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/paymentcase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/paymentcase.json
@@ -169,5 +169,6 @@
     "D8InferredRespondentGender" : "male",
     "D8PetitionerConsent" : "YES",
     "IssueDate": "2006-02-02",
-    "dueDate":"2006-02-10"
+    "dueDate":"2006-02-10",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
@@ -232,5 +232,6 @@
     ],
     "petitionerConsent" : "Yes",
     "issueDate": "2006-02-02T00:00:00.000+0000",
-    "dueDate": "2006-02-10T00:00:00.000+0000"
+    "dueDate": "2006-02-10T00:00:00.000+0000",
+    "respondentContactDetailsConfidential": "keep"
 }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
@@ -217,5 +217,6 @@
     },
     "petitionerConsent" : "Yes",
     "issueDate": "2006-02-02T00:00:00.000+0000",
-    "dueDate": "2006-02-10T00:00:00.000+0000"
+    "dueDate": "2006-02-10T00:00:00.000+0000",
+    "respondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
@@ -148,5 +148,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "keep"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -172,5 +172,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -135,5 +135,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
@@ -155,5 +155,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "male",
     "D8InferredRespondentGender": "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
@@ -152,5 +152,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "male",
     "D8InferredRespondentGender": "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
@@ -153,5 +153,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
@@ -135,5 +135,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
@@ -135,5 +135,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
@@ -135,5 +135,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
@@ -165,5 +165,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
@@ -147,5 +147,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
@@ -154,6 +154,7 @@
     "D8ReasonForDivorce2YearSepConsentGiven" : "Yes",
     "D8MentalSeparationDate": "2015-03-01",
     "D8PhysicalSeparationDate": "2015-02-01",
+    "RespondentContactDetailsConfidential": "share",
     "D8SeparationTimeTogetherPermitted":"3 months, 2 weeks and 5 months",
     "D8LivedTogetherMoreTimeThanPermitted":"YES",
     "D8LivedApartSinceSeparation":"YES"

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
@@ -146,5 +146,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
@@ -144,5 +144,6 @@
     "D8Cohort": "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender": "female",
     "D8InferredRespondentGender": "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
@@ -243,5 +243,6 @@
         }
     }],
     "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "keep",
     "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment.json
@@ -230,5 +230,6 @@
         "PaymentSiteId" : "AA00"
     },
     "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "share",
     "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -507,6 +507,9 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("D8PhysicalSeparationDate")
     private String reasonForDivorceLivingApartDate;
 
+    @JsonProperty("RespondentContactDetailsConfidential")
+    private String respondentContactDetailsConfidential;
+  
     @JsonProperty("D8SeparationTimeTogetherPermitted")
     private String separationTimeTogetherPermitted;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -343,6 +343,9 @@ public class DivorceSession {
             + "\"yyyy-MM-dd'T'HH:mm:ss.SSS\", \"EEE, dd MMM yyyy HH:mm:ss zzz\", \"yyyy-MM-dd\").")
     private Date reasonForDivorceLivingApartDate;
 
+    @ApiModelProperty(value = "Respondent contact details to be kept private?", allowableValues = "share, keep")
+    private String respondentContactDetailsConfidential;
+  
     @ApiModelProperty(value = "Maximum separation time together permitted?")
     private String separationTimeTogetherPermitted;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -49,6 +49,7 @@ public abstract class CCDCaseToDivorceMapper {
     @Mapping(source = "d8CountryName", target = "countryName")
     @Mapping(source = "d8MarriagePlaceOfMarriage", target = "placeOfMarriage")
     @Mapping(source = "d8PetitionerContactDetailsConfidential", target = "petitionerContactDetailsConfidential")
+    @Mapping(source = "respondentContactDetailsConfidential", target = "respondentContactDetailsConfidential")
     @Mapping(source = "d8PetitionerHomeAddress.postCode", target = "petitionerHomeAddress.postcode")
     @Mapping(source = "d8PetitionerCorrespondenceAddress.postCode", target = "petitionerCorrespondenceAddress.postcode")
     @Mapping(source = "d8RespondentHomeAddress.postCode", target = "respondentHomeAddress.postcode")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -34,6 +34,8 @@ public abstract class DivorceCaseToCCDMapper {
     private static final String BLANK_SPACE = " ";
     private static final String LINE_SEPARATOR = "\n";
 
+    private static final String SHARE_DETAILS = "share";
+
     private final ReasonForDivorceContext reasonForDivorceContext = new ReasonForDivorceContext();
     private final PaymentContext paymentContext = new PaymentContext();
 
@@ -57,6 +59,7 @@ public abstract class DivorceCaseToCCDMapper {
     @Mapping(source = "countryName", target = "d8CountryName")
     @Mapping(source = "placeOfMarriage", target = "d8MarriagePlaceOfMarriage")
     @Mapping(source = "petitionerContactDetailsConfidential", target = "d8PetitionerContactDetailsConfidential")
+    @Mapping(source = "respondentContactDetailsConfidential", target = "respondentContactDetailsConfidential")
     @Mapping(source = "petitionerHomeAddress.postcode", target = "d8PetitionerHomeAddress.postCode")
     @Mapping(source = "petitionerCorrespondenceAddress.postcode", target = "d8PetitionerCorrespondenceAddress.postCode")
     @Mapping(source = "respondentHomeAddress.postcode", target = "d8RespondentHomeAddress.postCode")
@@ -625,6 +628,14 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapPetitionerConsent(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8PetitionerConsent(translateToStringYesNo(divorceSession.getPetitionerConsent()));
+    }
+
+    @AfterMapping
+    protected void mapRespondentContactDetailsConfidential(DivorceSession divorceSession,
+                                                            @MappingTarget CoreCaseData result) {
+        if (Objects.isNull(divorceSession.getRespondentContactDetailsConfidential())) {
+            result.setRespondentContactDetailsConfidential(SHARE_DETAILS);
+        }
     }
 
     @AfterMapping

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -36,6 +36,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     private static final String SHARE_DETAILS = "share";
 
+    private static final String SHARE_DETAILS = "share";
+
     private final ReasonForDivorceContext reasonForDivorceContext = new ReasonForDivorceContext();
     private final PaymentContext paymentContext = new PaymentContext();
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -36,8 +36,6 @@ public abstract class DivorceCaseToCCDMapper {
 
     private static final String SHARE_DETAILS = "share";
 
-    private static final String SHARE_DETAILS = "share";
-
     private final ReasonForDivorceContext reasonForDivorceContext = new ReasonForDivorceContext();
     private final PaymentContext paymentContext = new PaymentContext();
 

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/additionalpayment.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/additionalpayment.json
@@ -180,5 +180,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "keep"
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/paymentcase.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/paymentcase.json
@@ -170,5 +170,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
@@ -225,5 +225,6 @@
             "PaymentSiteId" : "AA00"
         }
     }],
-    "petitionerConsent" : "Yes"
+    "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "keep"
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
@@ -230,5 +230,6 @@
         "PaymentFeeId" : "X0165",
         "PaymentSiteId" : "AA00"
     },
-    "petitionerConsent" : "Yes"
+    "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
@@ -180,5 +180,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "keep"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -197,5 +197,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -165,5 +165,6 @@
     "D8DerivedReasonForDivorceAdultery3rdAddr" : null,
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/empty-respondent-home-addresscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/empty-respondent-home-addresscase.json
@@ -8,5 +8,6 @@
         "County" : null,
         "Country" : null
     },
-    "D8Cohort" : "onlineSubmissionPrivateBeta"
+    "D8Cohort" : "onlineSubmissionPrivateBeta",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "male",
     "D8InferredRespondentGender" : "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "male",
     "D8InferredRespondentGender" : "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/nulladdressfields.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/nulladdressfields.json
@@ -197,5 +197,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/nullfieldscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/nullfieldscase.json
@@ -149,5 +149,6 @@
     "D8ReasonForDivorceDesertion" : null,
     "D8DerivedReasonForDivorceAdultery3rdAddr" : null,
     "D8Cohort" : "onlineSubmissionPrivateBeta",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
@@ -167,5 +167,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
@@ -164,5 +164,6 @@
     "D8ReasonForDivorceDesertion" : null,
     "D8DerivedReasonForDivorceAdultery3rdAddr" : null,
     "D8Cohort" : "onlineSubmissionPrivateBeta",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
@@ -167,5 +167,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
@@ -195,5 +195,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation-LessThan6MonthLivedTogether.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation-LessThan6MonthLivedTogether.json
@@ -193,6 +193,7 @@
     "D8SeparationTimeTogetherPermitted":"3 months, 2 weeks and 5 months",
     "D8LivedTogetherMoreTimeThanPermitted":"YES",
     "D8LivedApartSinceSeparation":"YES",
-    "D8SeparationReferenceDate": "01 December 2013"
+    "D8SeparationReferenceDate": "01 December 2013",
+    "RespondentContactDetailsConfidential" : "share"
 
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
@@ -190,6 +190,7 @@
     "D8ReasonForDivorce2YearSepConsentGiven" : "Yes",
     "D8MentalSeparationDate": "2015-03-01",
     "D8PhysicalSeparationDate": "2015-02-01",
+    "RespondentContactDetailsConfidential": "share",
     "D8SeparationTimeTogetherPermitted":"3 months, 2 weeks and 5 months",
     "D8LivedTogetherMoreTimeThanPermitted":"YES",
     "D8LivedApartSinceSeparation":"YES",

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
@@ -186,5 +186,6 @@
     "D8Cohort" : "onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "female",
-    "D8PetitionerConsent" : "YES"
+    "D8PetitionerConsent" : "YES",
+    "RespondentContactDetailsConfidential": "share"
   }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
@@ -232,5 +232,6 @@
         }
     }],
     "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "keep",
     "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/payment.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/payment.json
@@ -218,5 +218,6 @@
         "PaymentSiteId" : "AA00"
     },
     "petitionerConsent" : "Yes",
+    "respondentContactDetailsConfidential": "share",
     "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695"
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3737

This adds the RespondentConfidential field back in. Before merge, need to verify the following:

- [ ] Production CCD Config has the RespondentContactDetailsConfidential defined and with CRU permissions for the citizen and caseworker-divorce-courtadmin_beta roles.