### PR TITLE
Replace exisitngPayment properties that are not null only

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/DivorceToCCDFormatErrorHandlingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/DivorceToCCDFormatErrorHandlingTest.java
@@ -8,14 +8,6 @@ import org.springframework.http.HttpStatus;
 import static org.junit.Assert.assertEquals;
 
 public class DivorceToCCDFormatErrorHandlingTest extends IntegrationTest {
-    private static final String INVALID_USER_TOKEN = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIwOTg3NjU0M"
-        + "yIsInN1YiI6IjEwMCIsImlhdCI6MTUwODk0MDU3MywiZXhwIjoxNTE5MzAzNDI3LCJkYXRhIjoiY2l0aXplbiIsInR5cGUiOiJBQ0NFU1MiL"
-        + "CJpZCI6IjEwMCIsImZvcmVuYW1lIjoiSm9obiIsInN1cm5hbWUiOiJEb2UiLCJkZWZhdWx0LXNlcnZpY2UiOiJEaXZvcmNlIiwibG9hIjoxL"
-        + "CJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d3Lmdvdi51ayIsImdyb3VwIjoiZGl2b3JjZSJ9.lkNr1vpAP5_Gu97TQa0cRtHu8I-QESzu8kMX"
-        + "CJOQrVU";
-    private static final String  UNAUTHORISED_JWT_EXCEPTION = "status 403 reading "
-        + "IdamUserService#retrieveUserDetails(String); content:\n";
-
     @Value("${case.formatter.service.transform.toccdformat.context-path}")
     private String contextPath;
 
@@ -30,15 +22,6 @@ public class DivorceToCCDFormatErrorHandlingTest extends IntegrationTest {
         assertEquals(HttpStatus.BAD_REQUEST.value(),
             RestUtil.postToRestService(getAPIPath(), getHeaders(),
                 ResourceLoader.loadJson("fixtures/divorcetoccdmapping/divorce/addresses.json")).getStatusCode());
-    }
-
-    @Test
-    public void givenInvalidToken_whenTransformToCCDFormat_thenReturn403() throws Exception {
-        Response response = RestUtil.postToRestService(getAPIPath(), getHeaders(INVALID_USER_TOKEN),
-            ResourceLoader.loadJson("fixtures/divorcetoccdmapping/divorce/addresses.json"));
-
-        assertEquals(HttpStatus.FORBIDDEN.value(), response.getStatusCode());
-        assertEquals(UNAUTHORISED_JWT_EXCEPTION, response.asString());
     }
 
     @Override

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/DivorceToCCDFormatTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/DivorceToCCDFormatTest.java
@@ -62,7 +62,6 @@ public class DivorceToCCDFormatTest extends IntegrationTest {
         final String dateString =
             LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH));
         expectedOutput.put("createdDate", dateString);
-        expectedOutput.put("D8PetitionerEmail", EMAIL_ADDRESS);
 
         final Map<String, Object> actualOutput = getActual(response.getBody().asString());
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/IntegrationTest.java
@@ -17,7 +17,6 @@ import java.util.Map;
 @ContextConfiguration(classes = {ServiceContextConfiguration.class})
 public abstract class IntegrationTest {
     private static final String USER_NAME = "caseformatterservicetest";
-    static final String EMAIL_ADDRESS = USER_NAME + "@test.com";
     private static final String password = "passowrd";
 
     private String userToken;

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/additionalpayment.json
@@ -9,7 +9,7 @@
     "D8MarriageDate": "2001-02-02",
     "D8MarriedInUk": "YES",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -9,7 +9,7 @@
     "D8MarriageDate": "2001-02-02",
     "D8MarriedInUk": "YES",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/hownamechanged.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdiction612.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/jurisdictionall.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "YES",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/overwritepayment.json
@@ -9,7 +9,7 @@
     "D8MarriageDate": "2001-02-02",
     "D8MarriedInUk": "YES",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentcase.json
@@ -9,7 +9,7 @@
     "D8MarriageDate": "2001-02-02",
     "D8MarriedInUk": "YES",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/paymentidonly.json
@@ -9,7 +9,7 @@
     "D8MarriageDate": "2001-02-02",
     "D8MarriedInUk": "YES",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonadultery.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasondesertion.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonseparation.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/reasonunreasonablebehaviour.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "NO",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/samesex.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple": "YES",
     "D8MarriageDate": "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert": "YES",
-    "D8PetitionerEmail": "caseformatterservicetest@test.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber": "01234567890",
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/payment/Payment.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/payment/Payment.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Data;
 
 @ApiModel(value = "Payment details.")
 @Data
+@Builder
 public class Payment {
 
     @ApiModelProperty("Payment channel.")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.caseformatterservice.service.impl;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.AosCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
@@ -18,7 +17,6 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.DivorceCaseToDnCa
 import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.DocumentCollectionDocumentRequestMapper;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.service.CaseFormatterService;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.service.IdamUserService;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.util.AuthUtil;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
@@ -46,9 +46,6 @@ public class CaseFormatterServiceImpl implements CaseFormatterService {
 
     @Override
     public CoreCaseData transformToCCDFormat(DivorceSession divorceSession, String authorisation) {
-        UserDetails userDetails = idamUserService.retrieveUserDetails(AuthUtil.getBearToken(authorisation));
-        divorceSession.setPetitionerEmail(userDetails.getEmail());
-
         return divorceCaseToCCDMapper.divorceCaseDataToCourtCaseData(divorceSession);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategy.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Pay
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -28,7 +29,26 @@ public class ExistingPaymentReferenceStrategy implements PaymentStrategy {
 
     private PaymentCollection mapExistingPayment(PaymentCollection existingPayment, Payment newPayment) {
         if (existingPayment.getValue().getPaymentReference().equals(newPayment.getPaymentReference())) {
-            return existingPayment.toBuilder().value(newPayment).build();
+            // Overwrite non-null values only, as we could get a subset of payment data to be updated
+            Payment updatedPayment = Payment.builder()
+                .paymentReference(newPayment.getPaymentReference())
+                .paymentAmount(Optional.ofNullable(newPayment.getPaymentAmount())
+                    .orElse(existingPayment.getValue().getPaymentAmount()))
+                .paymentChannel(Optional.ofNullable(newPayment.getPaymentChannel())
+                    .orElse(existingPayment.getValue().getPaymentChannel()))
+                .paymentDate(Optional.ofNullable(newPayment.getPaymentDate())
+                    .orElse(existingPayment.getValue().getPaymentDate()))
+                .paymentFeeId(Optional.ofNullable(newPayment.getPaymentFeeId())
+                    .orElse(existingPayment.getValue().getPaymentFeeId()))
+                .paymentSiteId(Optional.ofNullable(newPayment.getPaymentSiteId())
+                    .orElse(existingPayment.getValue().getPaymentSiteId()))
+                .paymentStatus(Optional.ofNullable(newPayment.getPaymentStatus())
+                    .orElse(existingPayment.getValue().getPaymentStatus()))
+                .paymentTransactionId(Optional.ofNullable(newPayment.getPaymentTransactionId())
+                    .orElse(existingPayment.getValue().getPaymentTransactionId()))
+                .build();
+
+            return existingPayment.toBuilder().value(updatedPayment).build();
         }
 
         return existingPayment;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/TransformToCCDFormatITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/TransformToCCDFormatITest.java
@@ -85,20 +85,6 @@ public class TransformToCCDFormatITest {
     }
 
     @Test
-    public void givenInvalidUserToken_whenTransformToCCDFormat_thenReturnForbiddenError() throws Exception {
-        final String message = "some message";
-        stubUserDetailsEndpoint(HttpStatus.FORBIDDEN, new EqualToPattern(USER_TOKEN), message);
-
-        webClient.perform(post(API_URL)
-            .content(ObjectMapperTestUtil.retrieveFileContents(PAYLOAD_PATH))
-            .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isForbidden())
-            .andExpect(content().string(containsString(message)));
-    }
-
-    @Test
     public void givenValidDetails_whenTransformToCCDFormat_thenReturnExpected() throws Exception {
         final String message = getUserDetails();
         stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(USER_TOKEN), message);
@@ -107,7 +93,6 @@ public class TransformToCCDFormatITest {
             ObjectMapperTestUtil.retrieveFileContentsAsObject(EXPECTED_PAYLOAD_PATH, CoreCaseData.class);
 
         expectedCaseData.setCreatedDate(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        expectedCaseData.setD8PetitionerEmail(EMAIL_ADDRESS);
 
         webClient.perform(post(API_URL)
             .content(ObjectMapperTestUtil.retrieveFileContents(PAYLOAD_PATH))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImplUTest.java
@@ -65,26 +65,18 @@ public class CaseFormatterServiceImplUTest {
     @Test
     public void whenTransformToCCDFormat_thenProceedAsExpected() {
         final String userToken = "someToken";
-        final String bearerUserToken = "Bearer someToken";
         final DivorceSession divorceSession = new DivorceSession();
-
-        final String emailAddress = "someEmailAddress";
-        final DivorceSession divorceSessionWithEmailAddress = new DivorceSession();
-        divorceSessionWithEmailAddress.setPetitionerEmail(emailAddress);
 
         final CoreCaseData expectedCaseData = new CoreCaseData();
 
-        when(idamUserService.retrieveUserDetails(bearerUserToken))
-            .thenReturn(UserDetails.builder().email(emailAddress).build());
-        when(divorceCaseToCCDMapper.divorceCaseDataToCourtCaseData(divorceSessionWithEmailAddress))
+        when(divorceCaseToCCDMapper.divorceCaseDataToCourtCaseData(divorceSession))
             .thenReturn(expectedCaseData);
 
         final CoreCaseData actualCaseData = classUnderTest.transformToCCDFormat(divorceSession, userToken);
 
         assertEquals(expectedCaseData, actualCaseData);
 
-        verify(idamUserService).retrieveUserDetails(bearerUserToken);
-        verify(divorceCaseToCCDMapper).divorceCaseDataToCourtCaseData(divorceSessionWithEmailAddress);
+        verify(divorceCaseToCCDMapper).divorceCaseDataToCourtCaseData(divorceSession);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/ExistingPaymentReferenceStrategyUTest.java
@@ -34,10 +34,31 @@ public class ExistingPaymentReferenceStrategyUTest {
         assertThat(returnedPaymentsList, equalTo(expectedPaymentsList));
     }
 
+    @Test
+    public void testExistingPaymentReferenceAndSubsetOfPaymentWillUpdatePayment() {
+        final PaymentCollection newPayment = createPayment("111222333", null, "123456789");
+        final PaymentCollection existingPayment = createPayment("999888777", "success", "12345");
+        final PaymentCollection toBeReplacedPayment = createPayment("111222333", "created", "123");
+
+        final List<PaymentCollection> existingPaymentsList = new ArrayList<>();
+        existingPaymentsList.add(existingPayment);
+        existingPaymentsList.add(toBeReplacedPayment);
+
+        final PaymentCollection updatedNewPayment = createPayment("111222333", "created", "123");
+
+        final List<PaymentCollection> expectedPaymentsList = asList(existingPayment, updatedNewPayment);
+        final List<PaymentCollection> returnedPaymentsList = existingPaymentReferenceStrategy
+            .getCurrentPaymentsList(newPayment.getValue(), existingPaymentsList);
+
+        assertThat(returnedPaymentsList, equalTo(expectedPaymentsList));
+    }
+
+
     private PaymentCollection createPayment(String reference, String status, String collectionId) {
-        final Payment payment = new Payment();
-        payment.setPaymentReference(reference);
-        payment.setPaymentStatus(status);
+        final Payment payment = Payment.builder()
+            .paymentReference(reference)
+            .paymentStatus(status)
+            .build();
 
         return PaymentCollection.builder().id(collectionId).value(payment).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/NoExistingPaymentReferenceStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/NoExistingPaymentReferenceStrategyUTest.java
@@ -33,9 +33,10 @@ public class NoExistingPaymentReferenceStrategyUTest {
     }
 
     private PaymentCollection createPayment(String reference, String status) {
-        final Payment payment = new Payment();
-        payment.setPaymentReference(reference);
-        payment.setPaymentStatus(status);
+        final Payment payment = Payment.builder()
+            .paymentReference(reference)
+            .paymentStatus(status)
+            .build();
 
         return PaymentCollection.builder().value(payment).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/NoExistingPaymentStrategyUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/NoExistingPaymentStrategyUTest.java
@@ -15,8 +15,7 @@ public class NoExistingPaymentStrategyUTest {
 
     @Test
     public void testNoExistingPaymentsAddsJustNewPayment() {
-        final Payment newPayment = new Payment();
-        newPayment.setPaymentReference("111222333");
+        final Payment newPayment = Payment.builder().paymentReference("111222333").build();
 
         final List<PaymentCollection> existingPaymentsList = null;
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/PaymentContextUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/strategy/payment/PaymentContextUTest.java
@@ -41,9 +41,10 @@ public class PaymentContextUTest {
     }
 
     private Payment createPayment(String reference, String status) {
-        final Payment payment = new Payment();
-        payment.setPaymentReference(reference);
-        payment.setPaymentStatus(status);
+        final Payment payment = Payment.builder()
+            .paymentReference(reference)
+            .paymentStatus(status)
+            .build();
 
         return payment;
     }


### PR DESCRIPTION
# Description

For [DIV-3645](https://tools.hmcts.net/jira/browse/DIV-3645)

Payment callback returns a response like:
{"_links":{"self":{"href":"http://payment-api-aat.service.core-compute-aat.internal/card-payments/RC-1549-3140-5487-8260","method":"GET","methAod":"GET"}},"amount":550,"ccd_case_number":"1549314051019462","channel":"online","currency":"GBP","description":"Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.","external_provider":"gov pay","external_reference":"555ufapesk8daponmgffe4b3vv","fees":[{"calculated_amount":550,"code":"FEE0002","version":"4","volume":1}],"method":"card","payment_group_reference":"2019-15493140548","reference":"RC-1549-3140-5487-8260","service_name":"Divorce","site_id":"CTSC","status":"Success"}

Which is missing the created_date property, which we use to populate the PaymentDate.

This change on the mapper only replaces Existing Payment details if the new property is not null. Since this is an Update payment event, we should ideally already have the Created Date already in the initial payment, so on the payment callback if payment date is null, then we will just use the existing payment. As we now know we can get a subset of payment data, I'm applying the check to every property we require on payments.