### PR TITLE
Set TimeLivedTogetherDetails based on reason for Divorce

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnCaseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnCaseMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -34,11 +35,8 @@ public abstract class DivorceCaseToDnCaseMapper {
     @Mapping(source = "behaviourContinuedSinceApplication", target = "behaviourStillHappeningDN")
     @Mapping(source = "lastIncidentDate", dateFormat = SIMPLE_DATE_FORMAT, target = "behaviourMostRecentIncidentDateDN")
     @Mapping(source = "livedApartSinceLastIncidentDate", target = "behaviourLivedApartSinceEventDN")
-    @Mapping(source = "approximateDatesOfLivingTogetherField", target = "behaviourTimeLivedTogetherDetailsDN")
     @Mapping(source = "livedApartSinceDesertion", target = "desertionLivedApartSinceEventDN")
-    @Mapping(source = "approximateDatesOfLivingTogetherField", target = "desertionTimeLivedTogetherDetailsDN")
     @Mapping(source = "livedApartSinceSeparation", target = "separationLivedApartSinceEventDN")
-    @Mapping(source = "approximateDatesOfLivingTogetherField", target = "separationTimeLivedTogetherDetailsDN")
     public abstract DnCaseData divorceCaseDataToDnCaseData(DivorceSession divorceSession);
 
     @AfterMapping
@@ -54,7 +52,6 @@ public abstract class DivorceCaseToDnCaseMapper {
             result.setConfirmPetitionDN(YES);
         }
     }
-
 
     @AfterMapping
     protected void mapAgreeToApplyDn(DivorceSession divorceSession, @MappingTarget DnCaseData result) {
@@ -72,6 +69,33 @@ public abstract class DivorceCaseToDnCaseMapper {
     protected void mapPetitionChangedYesNoDN(DivorceSession divorceSession, @MappingTarget DnCaseData result) {
 
         result.setPetitionChangedYesNoDN(translateToStringYesNo(divorceSession.getHasBeenChanges()));
+    }
+
+    @AfterMapping
+    protected void mapBehaviourTimeLivedTogetherDetailsDN(DivorceSession divorceSession,
+                                                          @MappingTarget DnCaseData result) {
+
+        if (StringUtils.isNotBlank(divorceSession.getLivedApartSinceLastIncidentDate())) {
+            result.setBehaviourTimeLivedTogetherDetailsDN(divorceSession.getApproximateDatesOfLivingTogetherField());
+        }
+    }
+
+    @AfterMapping
+    protected void mapDesertionTimeLivedTogetherDetailsDN(DivorceSession divorceSession,
+                                                          @MappingTarget DnCaseData result) {
+
+        if (StringUtils.isNotBlank(divorceSession.getLivedApartSinceDesertion())) {
+            result.setDesertionTimeLivedTogetherDetailsDN(divorceSession.getApproximateDatesOfLivingTogetherField());
+        }
+    }
+
+    @AfterMapping
+    protected void mapSeparationTimeLivedTogetherDetailsDN(DivorceSession divorceSession,
+                                                          @MappingTarget DnCaseData result) {
+
+        if (StringUtils.isNotBlank(divorceSession.getLivedApartSinceSeparation())) {
+            result.setSeparationTimeLivedTogetherDetailsDN(divorceSession.getApproximateDatesOfLivingTogetherField());
+        }
     }
 
     private String translateToStringYesNo(final String value) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/DivorceCaseToDnCaseMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/DivorceCaseToDnCaseMapperUTest.java
@@ -35,7 +35,59 @@ public class DivorceCaseToDnCaseMapperUTest {
             LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         DivorceSession divorceSession = ObjectMapperTestUtil
-            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn.json", DivorceSession.class);
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn.json",
+                DivorceSession.class);
+
+        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceSession);
+
+        assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
+    }
+
+    @Test
+    public void shouldMapTheFieldsProperlyForBehaviour() throws URISyntaxException, IOException {
+
+        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-behaviour.json", DnCaseData.class);
+        expectedDnCaseData.setDnApplicationSubmittedDate(
+            LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-behaviour.json",
+                DivorceSession.class);
+
+        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceSession);
+
+        assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
+    }
+
+    @Test
+    public void shouldMapTheFieldsProperlyForDesertion() throws URISyntaxException, IOException {
+
+        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-desertion.json", DnCaseData.class);
+        expectedDnCaseData.setDnApplicationSubmittedDate(
+            LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-desertion.json",
+                DivorceSession.class);
+
+        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceSession);
+
+        assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
+    }
+
+    @Test
+    public void shouldMapTheFieldsProperlyForSeparation() throws URISyntaxException, IOException {
+
+        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-separation.json", DnCaseData.class);
+        expectedDnCaseData.setDnApplicationSubmittedDate(
+            LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-separation.json",
+                DivorceSession.class);
 
         DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceSession);
 

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-behaviour.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-behaviour.json
@@ -1,0 +1,45 @@
+{
+    "PetitionChangedYesNoDN" : "YES",
+    "PetitionChangedDetailsDN" : "Some details about this dn changes",
+    "ConfirmPetitionDN" : "YES",
+    "DivorceCostsOptionDN" : "differentAmount",
+    "CostsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruthDN" : "YES",
+    "BehaviourStillHappeningDN" : "NO",
+    "BehaviourMostRecentIncidentDateDN" : "2018-10-03",
+    "BehaviourLivedApartSinceEventDN" : "NO",
+    "BehaviourTimeLivedTogetherDetailsDN" : "Since we've met in a bar",
+    "DocumentsUploadedDN" : [
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "govuklogo.png",
+                "DocumentEmailContent" : ""
+            }
+        },
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType": "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded": "2017-12-11",
+                "DocumentComment": "",
+                "DocumentFileName": "d8-eng.pdf",
+                "DocumentEmailContent": ""
+            }
+        }
+    ],
+    "DocumentsUploadedQuestionDN" : "YES"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-desertion.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-desertion.json
@@ -1,0 +1,43 @@
+{
+    "PetitionChangedYesNoDN" : "YES",
+    "PetitionChangedDetailsDN" : "Some details about this dn changes",
+    "ConfirmPetitionDN" : "YES",
+    "DivorceCostsOptionDN" : "differentAmount",
+    "CostsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruthDN" : "YES",
+    "DesertionLivedApartSinceEventDN" : "NO",
+    "DesertionTimeLivedTogetherDetailsDN" : "Since we've met in a bar",
+    "DocumentsUploadedDN" : [
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "govuklogo.png",
+                "DocumentEmailContent" : ""
+            }
+        },
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType": "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded": "2017-12-11",
+                "DocumentComment": "",
+                "DocumentFileName": "d8-eng.pdf",
+                "DocumentEmailContent": ""
+            }
+        }
+    ],
+    "DocumentsUploadedQuestionDN" : "YES"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-separation.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-separation.json
@@ -1,0 +1,43 @@
+{
+    "PetitionChangedYesNoDN" : "YES",
+    "PetitionChangedDetailsDN" : "Some details about this dn changes",
+    "ConfirmPetitionDN" : "YES",
+    "DivorceCostsOptionDN" : "differentAmount",
+    "CostsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruthDN" : "YES",
+    "SeparationLivedApartSinceEventDN" : "NO",
+    "SeparationTimeLivedTogetherDetailsDN" : "Since we've met in a bar",
+    "DocumentsUploadedDN" : [
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "govuklogo.png",
+                "DocumentEmailContent" : ""
+            }
+        },
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType": "other",
+                "DocumentLink" : {
+                    "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+                    "document_binary_url" : null,
+                    "document_filename" : null
+                },
+                "DocumentDateAdded": "2017-12-11",
+                "DocumentComment": "",
+                "DocumentFileName": "d8-eng.pdf",
+                "DocumentEmailContent": ""
+            }
+        }
+    ],
+    "DocumentsUploadedQuestionDN" : "YES"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-behaviour.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-behaviour.json
@@ -1,0 +1,326 @@
+{
+    "expires":0,
+    "caseReference" : "caseReference",
+    "screenHasMarriageBroken":"Yes",
+    "screenHasRespondentAddress":"Yes",
+    "screenHasMarriageCert":"Yes",
+    "screenHasPrinter":"Yes",
+    "helpWithFeesNeedHelp":"Yes",
+    "helpWithFeesAppliedForFees":"Yes",
+    "helpWithFeesReferenceNumber":"HWF-123-456",
+    "divorceWho":"husband",
+    "marriageIsSameSexCouple":"No",
+    "marriageDateDay":2,
+    "marriageDateMonth":2,
+    "marriageDateYear":2001,
+    "marriageDate":"2001-02-02T00:00:00.000Z",
+    "marriageCanDivorce":true,
+    "marriageDateIsFuture":false,
+    "marriageDateMoreThan100":false,
+    "marriageWhereMarried":"england",
+    "petitionerContactDetailsConfidential":"share",
+    "petitionerFirstName":"John",
+    "petitionerLastName":"Smith",
+    "respondentFirstName":"Jane",
+    "respondentLastName":"Jamed",
+    "marriagePetitionerName":"John Doe",
+    "marriageRespondentName":"Jenny Benny",
+    "petitionerNameDifferentToMarriageCertificate":"Yes",
+    "petitionerNameChangedHow":[
+        "marriageCertificate"
+    ],
+    "petitionerEmail":"simulate-delivered@notifications.service.gov.uk",
+    "petitionerPhoneNumber":"01234567890",
+    "petitionerHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceUseHomeAddress":"No",
+    "livingArrangementsLiveTogether":"No",
+    "respondentCorrespondenceUseHomeAddress":"Solicitor",
+    "reasonForDivorce":"unreasonable-behaviour",
+    "reasonForDivorceHasMarriageDate":true,
+    "reasonForDivorceShowAdultery":true,
+    "reasonForDivorceShowUnreasonableBehaviour":true,
+    "reasonForDivorceShowTwoYearsSeparation":true,
+    "reasonForDivorceShowFiveYearsSeparation":true,
+    "reasonForDivorceShowDesertion":true,
+    "reasonForDivorceLimitReasons":false,
+    "reasonForDivorceEnableAdultery":true,
+    "reasonForDivorceBehaviourDetails":[
+        "My wife is having an affair this week."
+    ],
+    "legalProceedings":"Yes",
+    "legalProceedingsRelated":[
+        "children"
+    ],
+    "legalProceedingsDetails":"The legal proceeding details",
+    "financialOrder":"Yes",
+    "financialOrderFor":[
+        "petitioner",
+        "children"
+    ],
+    "claimsCosts":"Yes",
+    "reasonForDivorceAdulteryIsNamed":"No",
+    "claimsCostsFrom":[
+        "respondent"
+    ],
+    "claimsCostsAppliedForFees":true,
+    "reasonForDivorceClaiming5YearSeparation":false,
+    "reasonForDivorceClaimingAdultery":false,
+    "marriageCertificateFiles":[
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"govuklogo.png",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936"
+        },
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"d8-eng.pdf",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683"
+        }
+    ],
+    "court":{
+        "eastMidlands":{
+            "divorceCentre":"East Midlands Regional Divorce Centre",
+            "courtCity":"Nottingham",
+            "poBox":"PO Box 10447",
+            "postCode":"NG2 9QN",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"eastmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA01"
+        },
+        "westMidlands":{
+            "divorceCentre":"West Midlands Regional Divorce Centre",
+            "courtCity":"Stoke-on-Trent",
+            "poBox":"PO Box 3650",
+            "postCode":"ST4 9NH",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"westmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA02"
+        },
+        "southWest":{
+            "divorceCentre":"South West Regional Divorce Centre",
+            "courtCity":"Southampton",
+            "poBox":"PO Box 1792",
+            "postCode":"SO15 9GG",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"sw-region-divorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA03"
+        },
+        "northWest":{
+            "divorceCentre":"North West Regional Divorce Centre",
+            "divorceCentreAddressName":"Liverpool Civil & Family Court",
+            "courtCity":"Liverpool",
+            "street":"35 Vernon Street",
+            "postCode":"L2 2BX",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"family@liverpool.countycourt.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA04"
+        },
+        "serviceCentre": {
+            "serviceCentreName": "Courts and Tribunals Service Centre",
+            "divorceCentre": "East Midlands Regional Divorce Centre",
+            "courtCity": "Nottingham",
+            "poBox": "PO Box 10447",
+            "postCode": "NG2 9QN",
+            "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+            "email": "divorcecase@justice.gov.uk",
+            "phoneNumber": "0300 303 0642",
+            "siteId": "AA01"
+        }
+    },
+    "courts":"eastMidlands",
+    "jurisdictionConnection":[
+        "A",
+        "C"
+    ],
+    "connections":{
+        "A":"The Petitioner and the Respondent are habitually resident in England and Wales",
+        "C":"The Respondent is habitually resident in England and Wales"
+    },
+    "jurisdictionPetitionerResidence":"Yes",
+    "jurisdictionRespondentResidence":"Yes",
+    "jurisdictionConfidentLegal":"Yes",
+    "respondentCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"AB24 232",
+        "address":[
+            "84 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "84 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB24 232"
+        }
+    },
+    "livingArrangementsLastLivedTogether":"No",
+    "livingArrangementsLastLivedTogetherAddress":{
+        "addressType":"postcode",
+        "postcode":"AB22 222",
+        "address":[
+            "Flat A-B",
+            "86 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "Flat A-B",
+                "86 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB22 222"
+        }
+    },
+    "respondentLivesAtLastAddress":"No",
+    "respondentHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SS SSS",
+        "address":[
+            "88 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "88 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"SS SSS"
+        }
+    },
+    "respondentSolicitorName":"Justin",
+    "respondentSolicitorCompany":"Case",
+    "respondentSolicitorAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "90 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "90 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"A AAA"
+        }
+    },
+    "petitionerConsent" : "Yes",
+    "permittedDecreeNisiReason" : "0",
+    "respConfirmReadPetition" : "YES",
+    "respAdmitOrConsentToFact" : "YES",
+    "respWillDefendDivorce" : "YES",
+    "respJurisdictionAgree" : "NO",
+    "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
+    "respJurisdictionRespCountryOfResidence" : "UK",
+    "respLegalProceedingsExist" : "YES",
+    "respLegalProceedingsDescription" : "Some Description",
+    "respAgreeToCosts" : "NO",
+    "respCostsAmount" : "1232321",
+    "respCostsReason" : "Some Reason",
+    "respEmailAddress" : "est@somemail.com",
+    "respPhoneNumber" : "12344555",
+    "respStatementOfTruth" : "YES",
+    "respConsentToEmail" : "NO",
+    "respConsiderFinancialSituation" : "YES",
+    "respHardshipDefenseResponse" : "NO",
+    "respHardshipDescription" : "Some Hardship Description goes here",
+    "hasBeenChanges" : "yes",
+    "changesDetails" : "Some details about this dn changes",
+    "statementOfTruthChanges" : "YES",
+    "claimCosts" : "differentAmount",
+    "costsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruth" : "YES",
+    "behaviourContinuedSinceApplication" : "NO",
+    "lastIncidentDate" : "2018-10-03T00:00:00.000Z",
+    "livedApartSinceLastIncidentDate" : "NO",
+    "approximateDatesOfLivingTogetherField" : "Since we've met in a bar",
+    "files" : [
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "govuklogo.png",
+            "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+            "mimeType" : "image/png",
+            "status" : "OK"
+        },
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "d8-eng.pdf",
+            "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+            "mimeType" : "application/pdf",
+            "status" : "OK"
+        }
+    ],
+    "uploadAnyOtherDocuments" : "Yes"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-desertion.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-desertion.json
@@ -1,0 +1,324 @@
+{
+    "expires":0,
+    "caseReference" : "caseReference",
+    "screenHasMarriageBroken":"Yes",
+    "screenHasRespondentAddress":"Yes",
+    "screenHasMarriageCert":"Yes",
+    "screenHasPrinter":"Yes",
+    "helpWithFeesNeedHelp":"Yes",
+    "helpWithFeesAppliedForFees":"Yes",
+    "helpWithFeesReferenceNumber":"HWF-123-456",
+    "divorceWho":"husband",
+    "marriageIsSameSexCouple":"No",
+    "marriageDateDay":2,
+    "marriageDateMonth":2,
+    "marriageDateYear":2001,
+    "marriageDate":"2001-02-02T00:00:00.000Z",
+    "marriageCanDivorce":true,
+    "marriageDateIsFuture":false,
+    "marriageDateMoreThan100":false,
+    "marriageWhereMarried":"england",
+    "petitionerContactDetailsConfidential":"share",
+    "petitionerFirstName":"John",
+    "petitionerLastName":"Smith",
+    "respondentFirstName":"Jane",
+    "respondentLastName":"Jamed",
+    "marriagePetitionerName":"John Doe",
+    "marriageRespondentName":"Jenny Benny",
+    "petitionerNameDifferentToMarriageCertificate":"Yes",
+    "petitionerNameChangedHow":[
+        "marriageCertificate"
+    ],
+    "petitionerEmail":"simulate-delivered@notifications.service.gov.uk",
+    "petitionerPhoneNumber":"01234567890",
+    "petitionerHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceUseHomeAddress":"No",
+    "livingArrangementsLiveTogether":"No",
+    "respondentCorrespondenceUseHomeAddress":"Solicitor",
+    "reasonForDivorce":"unreasonable-behaviour",
+    "reasonForDivorceHasMarriageDate":true,
+    "reasonForDivorceShowAdultery":true,
+    "reasonForDivorceShowUnreasonableBehaviour":true,
+    "reasonForDivorceShowTwoYearsSeparation":true,
+    "reasonForDivorceShowFiveYearsSeparation":true,
+    "reasonForDivorceShowDesertion":true,
+    "reasonForDivorceLimitReasons":false,
+    "reasonForDivorceEnableAdultery":true,
+    "reasonForDivorceBehaviourDetails":[
+        "My wife is having an affair this week."
+    ],
+    "legalProceedings":"Yes",
+    "legalProceedingsRelated":[
+        "children"
+    ],
+    "legalProceedingsDetails":"The legal proceeding details",
+    "financialOrder":"Yes",
+    "financialOrderFor":[
+        "petitioner",
+        "children"
+    ],
+    "claimsCosts":"Yes",
+    "reasonForDivorceAdulteryIsNamed":"No",
+    "claimsCostsFrom":[
+        "respondent"
+    ],
+    "claimsCostsAppliedForFees":true,
+    "reasonForDivorceClaiming5YearSeparation":false,
+    "reasonForDivorceClaimingAdultery":false,
+    "marriageCertificateFiles":[
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"govuklogo.png",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936"
+        },
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"d8-eng.pdf",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683"
+        }
+    ],
+    "court":{
+        "eastMidlands":{
+            "divorceCentre":"East Midlands Regional Divorce Centre",
+            "courtCity":"Nottingham",
+            "poBox":"PO Box 10447",
+            "postCode":"NG2 9QN",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"eastmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA01"
+        },
+        "westMidlands":{
+            "divorceCentre":"West Midlands Regional Divorce Centre",
+            "courtCity":"Stoke-on-Trent",
+            "poBox":"PO Box 3650",
+            "postCode":"ST4 9NH",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"westmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA02"
+        },
+        "southWest":{
+            "divorceCentre":"South West Regional Divorce Centre",
+            "courtCity":"Southampton",
+            "poBox":"PO Box 1792",
+            "postCode":"SO15 9GG",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"sw-region-divorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA03"
+        },
+        "northWest":{
+            "divorceCentre":"North West Regional Divorce Centre",
+            "divorceCentreAddressName":"Liverpool Civil & Family Court",
+            "courtCity":"Liverpool",
+            "street":"35 Vernon Street",
+            "postCode":"L2 2BX",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"family@liverpool.countycourt.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA04"
+        },
+        "serviceCentre": {
+            "serviceCentreName": "Courts and Tribunals Service Centre",
+            "divorceCentre": "East Midlands Regional Divorce Centre",
+            "courtCity": "Nottingham",
+            "poBox": "PO Box 10447",
+            "postCode": "NG2 9QN",
+            "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+            "email": "divorcecase@justice.gov.uk",
+            "phoneNumber": "0300 303 0642",
+            "siteId": "AA01"
+        }
+    },
+    "courts":"eastMidlands",
+    "jurisdictionConnection":[
+        "A",
+        "C"
+    ],
+    "connections":{
+        "A":"The Petitioner and the Respondent are habitually resident in England and Wales",
+        "C":"The Respondent is habitually resident in England and Wales"
+    },
+    "jurisdictionPetitionerResidence":"Yes",
+    "jurisdictionRespondentResidence":"Yes",
+    "jurisdictionConfidentLegal":"Yes",
+    "respondentCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"AB24 232",
+        "address":[
+            "84 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "84 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB24 232"
+        }
+    },
+    "livingArrangementsLastLivedTogether":"No",
+    "livingArrangementsLastLivedTogetherAddress":{
+        "addressType":"postcode",
+        "postcode":"AB22 222",
+        "address":[
+            "Flat A-B",
+            "86 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "Flat A-B",
+                "86 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB22 222"
+        }
+    },
+    "respondentLivesAtLastAddress":"No",
+    "respondentHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SS SSS",
+        "address":[
+            "88 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "88 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"SS SSS"
+        }
+    },
+    "respondentSolicitorName":"Justin",
+    "respondentSolicitorCompany":"Case",
+    "respondentSolicitorAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "90 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "90 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"A AAA"
+        }
+    },
+    "petitionerConsent" : "Yes",
+    "permittedDecreeNisiReason" : "0",
+    "respConfirmReadPetition" : "YES",
+    "respAdmitOrConsentToFact" : "YES",
+    "respWillDefendDivorce" : "YES",
+    "respJurisdictionAgree" : "NO",
+    "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
+    "respJurisdictionRespCountryOfResidence" : "UK",
+    "respLegalProceedingsExist" : "YES",
+    "respLegalProceedingsDescription" : "Some Description",
+    "respAgreeToCosts" : "NO",
+    "respCostsAmount" : "1232321",
+    "respCostsReason" : "Some Reason",
+    "respEmailAddress" : "est@somemail.com",
+    "respPhoneNumber" : "12344555",
+    "respStatementOfTruth" : "YES",
+    "respConsentToEmail" : "NO",
+    "respConsiderFinancialSituation" : "YES",
+    "respHardshipDefenseResponse" : "NO",
+    "respHardshipDescription" : "Some Hardship Description goes here",
+    "hasBeenChanges" : "yes",
+    "changesDetails" : "Some details about this dn changes",
+    "statementOfTruthChanges" : "YES",
+    "claimCosts" : "differentAmount",
+    "costsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruth" : "YES",
+    "approximateDatesOfLivingTogetherField" : "Since we've met in a bar",
+    "livedApartSinceDesertion" : "NO",
+    "files" : [
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "govuklogo.png",
+            "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+            "mimeType" : "image/png",
+            "status" : "OK"
+        },
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "d8-eng.pdf",
+            "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+            "mimeType" : "application/pdf",
+            "status" : "OK"
+        }
+    ],
+    "uploadAnyOtherDocuments" : "Yes"
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-separation.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-separation.json
@@ -1,0 +1,324 @@
+{
+    "expires":0,
+    "caseReference" : "caseReference",
+    "screenHasMarriageBroken":"Yes",
+    "screenHasRespondentAddress":"Yes",
+    "screenHasMarriageCert":"Yes",
+    "screenHasPrinter":"Yes",
+    "helpWithFeesNeedHelp":"Yes",
+    "helpWithFeesAppliedForFees":"Yes",
+    "helpWithFeesReferenceNumber":"HWF-123-456",
+    "divorceWho":"husband",
+    "marriageIsSameSexCouple":"No",
+    "marriageDateDay":2,
+    "marriageDateMonth":2,
+    "marriageDateYear":2001,
+    "marriageDate":"2001-02-02T00:00:00.000Z",
+    "marriageCanDivorce":true,
+    "marriageDateIsFuture":false,
+    "marriageDateMoreThan100":false,
+    "marriageWhereMarried":"england",
+    "petitionerContactDetailsConfidential":"share",
+    "petitionerFirstName":"John",
+    "petitionerLastName":"Smith",
+    "respondentFirstName":"Jane",
+    "respondentLastName":"Jamed",
+    "marriagePetitionerName":"John Doe",
+    "marriageRespondentName":"Jenny Benny",
+    "petitionerNameDifferentToMarriageCertificate":"Yes",
+    "petitionerNameChangedHow":[
+        "marriageCertificate"
+    ],
+    "petitionerEmail":"simulate-delivered@notifications.service.gov.uk",
+    "petitionerPhoneNumber":"01234567890",
+    "petitionerHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceUseHomeAddress":"No",
+    "livingArrangementsLiveTogether":"No",
+    "respondentCorrespondenceUseHomeAddress":"Solicitor",
+    "reasonForDivorce":"unreasonable-behaviour",
+    "reasonForDivorceHasMarriageDate":true,
+    "reasonForDivorceShowAdultery":true,
+    "reasonForDivorceShowUnreasonableBehaviour":true,
+    "reasonForDivorceShowTwoYearsSeparation":true,
+    "reasonForDivorceShowFiveYearsSeparation":true,
+    "reasonForDivorceShowDesertion":true,
+    "reasonForDivorceLimitReasons":false,
+    "reasonForDivorceEnableAdultery":true,
+    "reasonForDivorceBehaviourDetails":[
+        "My wife is having an affair this week."
+    ],
+    "legalProceedings":"Yes",
+    "legalProceedingsRelated":[
+        "children"
+    ],
+    "legalProceedingsDetails":"The legal proceeding details",
+    "financialOrder":"Yes",
+    "financialOrderFor":[
+        "petitioner",
+        "children"
+    ],
+    "claimsCosts":"Yes",
+    "reasonForDivorceAdulteryIsNamed":"No",
+    "claimsCostsFrom":[
+        "respondent"
+    ],
+    "claimsCostsAppliedForFees":true,
+    "reasonForDivorceClaiming5YearSeparation":false,
+    "reasonForDivorceClaimingAdultery":false,
+    "marriageCertificateFiles":[
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"govuklogo.png",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936"
+        },
+        {
+            "createdBy":0,
+            "createdOn":"2017-12-11",
+            "lastModifiedBy":0,
+            "fileName":"d8-eng.pdf",
+            "fileUrl":"https://api-gateway.test.dm.reform.hmcts.net/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683"
+        }
+    ],
+    "court":{
+        "eastMidlands":{
+            "divorceCentre":"East Midlands Regional Divorce Centre",
+            "courtCity":"Nottingham",
+            "poBox":"PO Box 10447",
+            "postCode":"NG2 9QN",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"eastmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA01"
+        },
+        "westMidlands":{
+            "divorceCentre":"West Midlands Regional Divorce Centre",
+            "courtCity":"Stoke-on-Trent",
+            "poBox":"PO Box 3650",
+            "postCode":"ST4 9NH",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"westmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA02"
+        },
+        "southWest":{
+            "divorceCentre":"South West Regional Divorce Centre",
+            "courtCity":"Southampton",
+            "poBox":"PO Box 1792",
+            "postCode":"SO15 9GG",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"sw-region-divorce@hmcts.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA03"
+        },
+        "northWest":{
+            "divorceCentre":"North West Regional Divorce Centre",
+            "divorceCentreAddressName":"Liverpool Civil & Family Court",
+            "courtCity":"Liverpool",
+            "street":"35 Vernon Street",
+            "postCode":"L2 2BX",
+            "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
+            "email":"family@liverpool.countycourt.gsi.gov.uk",
+            "phoneNumber":"0300 303 0642",
+            "siteId":"AA04"
+        },
+        "serviceCentre": {
+            "serviceCentreName": "Courts and Tribunals Service Centre",
+            "divorceCentre": "East Midlands Regional Divorce Centre",
+            "courtCity": "Nottingham",
+            "poBox": "PO Box 10447",
+            "postCode": "NG2 9QN",
+            "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+            "email": "divorcecase@justice.gov.uk",
+            "phoneNumber": "0300 303 0642",
+            "siteId": "AA01"
+        }
+    },
+    "courts":"eastMidlands",
+    "jurisdictionConnection":[
+        "A",
+        "C"
+    ],
+    "connections":{
+        "A":"The Petitioner and the Respondent are habitually resident in England and Wales",
+        "C":"The Respondent is habitually resident in England and Wales"
+    },
+    "jurisdictionPetitionerResidence":"Yes",
+    "jurisdictionRespondentResidence":"Yes",
+    "jurisdictionConfidentLegal":"Yes",
+    "respondentCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "82 Landor Road",
+                "London"
+            ],
+            "postcode":"SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceAddress":{
+        "addressType":"postcode",
+        "postcode":"AB24 232",
+        "address":[
+            "84 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "84 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB24 232"
+        }
+    },
+    "livingArrangementsLastLivedTogether":"No",
+    "livingArrangementsLastLivedTogetherAddress":{
+        "addressType":"postcode",
+        "postcode":"AB22 222",
+        "address":[
+            "Flat A-B",
+            "86 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "Flat A-B",
+                "86 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"AB22 222"
+        }
+    },
+    "respondentLivesAtLastAddress":"No",
+    "respondentHomeAddress":{
+        "addressType":"postcode",
+        "postcode":"SS SSS",
+        "address":[
+            "88 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "88 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"SS SSS"
+        }
+    },
+    "respondentSolicitorName":"Justin",
+    "respondentSolicitorCompany":"Case",
+    "respondentSolicitorAddress":{
+        "addressType":"postcode",
+        "postcode":"SW9 9PE",
+        "address":[
+            "90 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed":"true",
+        "validPostcode":true,
+        "postcodeError":"false",
+        "formattedAddress":{
+            "whereabouts":[
+                "90 Landor Road",
+                "London",
+                "SW9 9PE"
+            ],
+            "postcode":"A AAA"
+        }
+    },
+    "petitionerConsent" : "Yes",
+    "permittedDecreeNisiReason" : "0",
+    "respConfirmReadPetition" : "YES",
+    "respAdmitOrConsentToFact" : "YES",
+    "respWillDefendDivorce" : "YES",
+    "respJurisdictionAgree" : "NO",
+    "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
+    "respJurisdictionRespCountryOfResidence" : "UK",
+    "respLegalProceedingsExist" : "YES",
+    "respLegalProceedingsDescription" : "Some Description",
+    "respAgreeToCosts" : "NO",
+    "respCostsAmount" : "1232321",
+    "respCostsReason" : "Some Reason",
+    "respEmailAddress" : "est@somemail.com",
+    "respPhoneNumber" : "12344555",
+    "respStatementOfTruth" : "YES",
+    "respConsentToEmail" : "NO",
+    "respConsiderFinancialSituation" : "YES",
+    "respHardshipDefenseResponse" : "NO",
+    "respHardshipDescription" : "Some Hardship Description goes here",
+    "hasBeenChanges" : "yes",
+    "changesDetails" : "Some details about this dn changes",
+    "statementOfTruthChanges" : "YES",
+    "claimCosts" : "differentAmount",
+    "costsDifferentDetails" : "I want to pay 60%",
+    "statementOfTruth" : "YES",
+    "approximateDatesOfLivingTogetherField" : "Since we've met in a bar",
+    "livedApartSinceSeparation" : "NO",
+    "files" : [
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "govuklogo.png",
+            "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+            "mimeType" : "image/png",
+            "status" : "OK"
+        },
+        {
+            "createdBy" : 12661,
+            "createdOn" : "2017-12-11",
+            "lastModifiedBy" : 12661,
+            "modifiedOn" : "2017-12-11",
+            "fileName" : "d8-eng.pdf",
+            "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+            "mimeType" : "application/pdf",
+            "status" : "OK"
+        }
+    ],
+    "uploadAnyOtherDocuments" : "Yes"
+}


### PR DESCRIPTION
# Description

[DIV-4216](https://tools.hmcts.net/jira/browse/DIV-4216)

Change the mapping for approximateDatesOfLivingTogetherField based on the reason for divorce. Since we do not have the actual reason for divorce field available at this point, used the other relevant fields to determine which field to map the above to.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
