### PR TITLE
DIV-4267 Add respDefendsDivorce

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -2,6 +2,7 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
+    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -274,6 +274,7 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
+    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
@@ -23,6 +23,9 @@ public class AosCaseData extends DnCaseData {
     @JsonProperty("RespWillDefendDivorce")
     private String respWillDefendDivorce;
 
+    @JsonProperty("RespDefendsDivorce")
+    private String respDefendsDivorce;
+
     @JsonProperty("RespJurisdictionDisagreeReason")
     private String respJurisdictionDisagreeReason;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -370,6 +370,9 @@ public class DivorceSession {
     private String respAdmitOrConsentToFact;
     @ApiModelProperty(value = "Will respondent defend the divorce?", allowableValues = "Yes, No, NoNoAdmission")
     private String respWillDefendDivorce;
+    @ApiModelProperty(value = "Will respondent defend the divorce - separation 2 years journey?",
+        allowableValues = "Yes, No")
+    private String respDefendsDivorce;
     @ApiModelProperty(value = "Reason respondent disagreed to claimed jurisdiction")
     private String respJurisdictionDisagreeReason;
     @ApiModelProperty(value = "Respondent country of residence")

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
@@ -205,6 +205,7 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
+    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
@@ -273,6 +273,7 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
+    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -2,6 +2,7 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
+    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -274,6 +274,7 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
+    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",


### PR DESCRIPTION
# Description

[DIV-4267](https://tools.hmcts.net/jira/browse/DIV-4267);

Adds respDefendsDivorce field to CCD and DivorceSession models. Since the field key names are the same, the AOSMapper automatically maps it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests and manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
