### PR TITLE
DIV-4275 Added mapping for CCD collection format in previous reasons for divorce

### DIFF
--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -208,6 +208,6 @@
     "D8PetitionerConsent" : "YES",
     "IssueDate": "2006-02-02",
     "dueDate":"2006-02-10",
-    "PreviousReasonsForDivorce": [{"id": "1234", "value": "reason-one"}, {"id": "1122", "value": "reason-two"}],
+    "PreviousReasonsForDivorce": [{"id": null, "value": "reason-one"}, {"id": null, "value": "reason-two"}],
     "PreviousCaseId": "caseReferenceOld"
   }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -208,6 +208,6 @@
     "D8PetitionerConsent" : "YES",
     "IssueDate": "2006-02-02",
     "dueDate":"2006-02-10",
-    "PreviousReasonsForDivorce": ["reason-one", "reason-two"],
+    "PreviousReasonsForDivorce": [{"id": "1234", "value": "reason-one"}, {"id": "1122", "value": "reason-two"}],
     "PreviousCaseId": "caseReferenceOld"
   }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -137,6 +137,6 @@
     "D8InferredRespondentGender": "male",
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
-    "PreviousReasonsForDivorce": ["reason-one", "reason-two"],
+    "PreviousReasonsForDivorce": [{"id": "1234", "value": "reason-one"}, {"id": "1122", "value": "reason-two"}],
     "PreviousCaseId": "caseReferenceOld"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -137,6 +137,9 @@
     "D8InferredRespondentGender": "male",
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
-    "PreviousReasonsForDivorce": [{"id": "1234", "value": "reason-one"}, {"id": "1122", "value": "reason-two"}],
+    "PreviousReasonsForDivorce": [
+        {"id": null, "value": "reason-one"},
+        {"id": null, "value": "reason-two"}
+    ],
     "PreviousCaseId": "caseReferenceOld"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -532,6 +532,6 @@ public class CoreCaseData extends AosCaseData {
     private String previousCaseId;
 
     @JsonProperty("PreviousReasonsForDivorce")
-    private List<String> previousReasonsForDivorce;
+    private List<CollectionMember> previousReasonsForDivorce;
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -350,7 +350,7 @@ public class DivorceSession {
 
     @ApiModelProperty(value = "Respondent contact details to be kept private?", allowableValues = "share, keep")
     private String respondentContactDetailsConfidential;
-  
+
     @ApiModelProperty(value = "Maximum separation time together permitted?")
     private String separationTimeTogetherPermitted;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/TranslateAnswer.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/TranslateAnswer.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 @AllArgsConstructor
 @Getter
-public enum YesNoNeverAnswer {
+public enum TranslateAnswer {
 
     YES("Yes"),
     NO("No"),
@@ -17,7 +17,7 @@ public enum YesNoNeverAnswer {
     private final String answer;
 
     @JsonCreator
-    public static YesNoNeverAnswer fromInput(String input) {
+    public static TranslateAnswer fromInput(String input) {
         if (input.equalsIgnoreCase(YES.getAnswer())) {
             return YES;
         } else if (input.equalsIgnoreCase(NO.getAnswer())) {
@@ -28,6 +28,6 @@ public enum YesNoNeverAnswer {
         throw new IllegalArgumentException(
                 String.format("Could not find match for input '%s' in %s",
                         input,
-                        Arrays.asList(YesNoNeverAnswer.values())));
+                        Arrays.asList(TranslateAnswer.values())));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/YesNoNeverAnswer.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/YesNoNeverAnswer.java
@@ -8,23 +8,26 @@ import java.util.Arrays;
 
 @AllArgsConstructor
 @Getter
-public enum YesNoAnswer {
+public enum YesNoNeverAnswer {
 
     YES("Yes"),
-    NO("No");
+    NO("No"),
+    NEVER("Never");
 
     private final String answer;
 
     @JsonCreator
-    public static YesNoAnswer fromInput(String input) {
+    public static YesNoNeverAnswer fromInput(String input) {
         if (input.equalsIgnoreCase(YES.getAnswer())) {
             return YES;
         } else if (input.equalsIgnoreCase(NO.getAnswer())) {
             return NO;
+        } else if (input.equalsIgnoreCase(NEVER.getAnswer())) {
+            return NEVER;
         }
         throw new IllegalArgumentException(
                 String.format("Could not find match for input '%s' in %s",
                         input,
-                        Arrays.asList(YesNoAnswer.values())));
+                        Arrays.asList(YesNoNeverAnswer.values())));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -144,6 +144,17 @@ public abstract class CCDCaseToDivorceMapper {
     }
 
     @AfterMapping
+    protected void previousCaseData(CoreCaseData caseData,
+                                    @MappingTarget DivorceSession divorceSession) {
+        if (caseData.getPreviousCaseId() == null) {
+            divorceSession.setPreviousCaseId(null);
+        }
+        if (caseData.getPreviousReasonsForDivorce() == null) {
+            divorceSession.setPreviousReasonsForDivorce(null);
+        }
+    }
+
+    @AfterMapping
     protected void mapMarriageDate(CoreCaseData caseData,
                                    @MappingTarget DivorceSession divorceSession) {
         if (caseData.getD8MarriageDate() != null) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCas
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.Address;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.AddressType;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.YesNoAnswer;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.YesNoNeverAnswer;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.AOS;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.Answer;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.CoRespondentAnswers;
@@ -133,7 +133,7 @@ public abstract class CCDCaseToDivorceMapper {
         if (Strings.isBlank(value)) {
             return null;
         }
-        return YesNoAnswer.fromInput(value).getAnswer();
+        return YesNoNeverAnswer.fromInput(value).getAnswer();
     }
 
     private String translateToBooleanString(final String value) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -27,7 +27,8 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 
-@Mapper(componentModel = "spring", uses = DocumentCollectionDivorceFormatMapper.class,
+@Mapper(componentModel = "spring", uses = {DocumentCollectionDivorceFormatMapper.class,
+    StringCollectionDivorceFormatMapper.class},
     unmappedTargetPolicy = ReportingPolicy.IGNORE)
 @SuppressWarnings({"PMD.GodClass", "common-java:DuplicatedBlocks"})
 public abstract class CCDCaseToDivorceMapper {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCas
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.Address;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.AddressType;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.YesNoNeverAnswer;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.TranslateAnswer;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.AOS;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.Answer;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.CoRespondentAnswers;
@@ -133,7 +133,7 @@ public abstract class CCDCaseToDivorceMapper {
         if (Strings.isBlank(value)) {
             return null;
         }
-        return YesNoNeverAnswer.fromInput(value).getAnswer();
+        return TranslateAnswer.fromInput(value).getAnswer();
     }
 
     private String translateToBooleanString(final String value) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
@@ -51,9 +51,12 @@ public abstract class DivorceCaseToAosCaseMapper {
         CoRespondentAnswers coRespondentAnswers = divorceSession.getCoRespondentAnswers();
 
         if (coRespondentAnswers != null) {
-            result.setReceivedAosFromCoResp(translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
-            result.setReceivedAnswerFromCoResp(translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
-            result.setCoRespConfirmReadPetition(translateToStringYesNoNever(coRespondentAnswers.getConfirmReadPetition()));
+            result.setReceivedAosFromCoResp(
+                translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+            result.setReceivedAnswerFromCoResp(
+                translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+            result.setCoRespConfirmReadPetition(
+                translateToStringYesNoNever(coRespondentAnswers.getConfirmReadPetition()));
             result.setCoRespStatementOfTruth(translateToStringYesNoNever(coRespondentAnswers.getStatementOfTruth()));
             result.setCoRespAdmitAdultery(translateToStringYesNoNever(coRespondentAnswers.getAdmitAdultery()));
             result.setCoRespDefendsDivorce(translateToStringYesNoNever(coRespondentAnswers.getDefendsDivorce()));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.CoRespondentAnswers;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
-import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNo;
+import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNoNever;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class DivorceCaseToAosCaseMapper {
@@ -51,17 +51,17 @@ public abstract class DivorceCaseToAosCaseMapper {
         CoRespondentAnswers coRespondentAnswers = divorceSession.getCoRespondentAnswers();
 
         if (coRespondentAnswers != null) {
-            result.setReceivedAosFromCoResp(translateToStringYesNo(coRespondentAnswers.getAnswer().getReceived()));
-            result.setReceivedAnswerFromCoResp(translateToStringYesNo(coRespondentAnswers.getAnswer().getReceived()));
-            result.setCoRespConfirmReadPetition(translateToStringYesNo(coRespondentAnswers.getConfirmReadPetition()));
-            result.setCoRespStatementOfTruth(translateToStringYesNo(coRespondentAnswers.getStatementOfTruth()));
-            result.setCoRespAdmitAdultery(translateToStringYesNo(coRespondentAnswers.getAdmitAdultery()));
-            result.setCoRespDefendsDivorce(translateToStringYesNo(coRespondentAnswers.getDefendsDivorce()));
-            result.setCoRespAgreeToCosts(translateToStringYesNo(coRespondentAnswers.getCosts().getAgreeToCosts()));
+            result.setReceivedAosFromCoResp(translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+            result.setReceivedAnswerFromCoResp(translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+            result.setCoRespConfirmReadPetition(translateToStringYesNoNever(coRespondentAnswers.getConfirmReadPetition()));
+            result.setCoRespStatementOfTruth(translateToStringYesNoNever(coRespondentAnswers.getStatementOfTruth()));
+            result.setCoRespAdmitAdultery(translateToStringYesNoNever(coRespondentAnswers.getAdmitAdultery()));
+            result.setCoRespDefendsDivorce(translateToStringYesNoNever(coRespondentAnswers.getDefendsDivorce()));
+            result.setCoRespAgreeToCosts(translateToStringYesNoNever(coRespondentAnswers.getCosts().getAgreeToCosts()));
             result.setCoRespConsentToEmail(
-                    translateToStringYesNo(coRespondentAnswers.getContactInfo().getConsentToReceivingEmails()));
+                    translateToStringYesNoNever(coRespondentAnswers.getContactInfo().getConsentToReceivingEmails()));
             result.setCoRespContactMethodIsDigital(
-                    translateToStringYesNo(coRespondentAnswers.getContactInfo().getContactMethodIsDigital()));
+                    translateToStringYesNoNever(coRespondentAnswers.getContactInfo().getContactMethodIsDigital()));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToAosCaseMapper.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.CoRespondentAnswers;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
-import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNoNever;
+import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToAnswer;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class DivorceCaseToAosCaseMapper {
@@ -52,19 +52,19 @@ public abstract class DivorceCaseToAosCaseMapper {
 
         if (coRespondentAnswers != null) {
             result.setReceivedAosFromCoResp(
-                translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+                translateToAnswer(coRespondentAnswers.getAnswer().getReceived()));
             result.setReceivedAnswerFromCoResp(
-                translateToStringYesNoNever(coRespondentAnswers.getAnswer().getReceived()));
+                translateToAnswer(coRespondentAnswers.getAnswer().getReceived()));
             result.setCoRespConfirmReadPetition(
-                translateToStringYesNoNever(coRespondentAnswers.getConfirmReadPetition()));
-            result.setCoRespStatementOfTruth(translateToStringYesNoNever(coRespondentAnswers.getStatementOfTruth()));
-            result.setCoRespAdmitAdultery(translateToStringYesNoNever(coRespondentAnswers.getAdmitAdultery()));
-            result.setCoRespDefendsDivorce(translateToStringYesNoNever(coRespondentAnswers.getDefendsDivorce()));
-            result.setCoRespAgreeToCosts(translateToStringYesNoNever(coRespondentAnswers.getCosts().getAgreeToCosts()));
+                translateToAnswer(coRespondentAnswers.getConfirmReadPetition()));
+            result.setCoRespStatementOfTruth(translateToAnswer(coRespondentAnswers.getStatementOfTruth()));
+            result.setCoRespAdmitAdultery(translateToAnswer(coRespondentAnswers.getAdmitAdultery()));
+            result.setCoRespDefendsDivorce(translateToAnswer(coRespondentAnswers.getDefendsDivorce()));
+            result.setCoRespAgreeToCosts(translateToAnswer(coRespondentAnswers.getCosts().getAgreeToCosts()));
             result.setCoRespConsentToEmail(
-                    translateToStringYesNoNever(coRespondentAnswers.getContactInfo().getConsentToReceivingEmails()));
+                    translateToAnswer(coRespondentAnswers.getContactInfo().getConsentToReceivingEmails()));
             result.setCoRespContactMethodIsDigital(
-                    translateToStringYesNoNever(coRespondentAnswers.getContactInfo().getContactMethodIsDigital()));
+                    translateToAnswer(coRespondentAnswers.getContactInfo().getContactMethodIsDigital()));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -19,12 +19,13 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorc
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
 
 import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
-import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNo;
+import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNoNever;
 
 @Mapper(componentModel = "spring", uses = {
     DocumentCollectionCCDFormatMapper.class, StringCollectionCCDFormatMapper.class},
@@ -136,314 +137,314 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapScreenHasMarriageBroken(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasMarriageBroken(translateToStringYesNo(divorceSession.getScreenHasMarriageBroken()));
+        result.setD8ScreenHasMarriageBroken(translateToStringYesNoNever(divorceSession.getScreenHasMarriageBroken()));
     }
 
     @AfterMapping
     protected void mapScreenHasRespondentAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasRespondentAddress(translateToStringYesNo(divorceSession.getScreenHasRespondentAddress()));
+        result.setD8ScreenHasRespondentAddress(translateToStringYesNoNever(divorceSession.getScreenHasRespondentAddress()));
     }
 
     @AfterMapping
     protected void mapScreenHasMarriageCert(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasMarriageCert(translateToStringYesNo(divorceSession.getScreenHasMarriageCert()));
+        result.setD8ScreenHasMarriageCert(translateToStringYesNoNever(divorceSession.getScreenHasMarriageCert()));
     }
 
     @AfterMapping
     protected void mapScreenHasPrinter(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasPrinter(translateToStringYesNo(divorceSession.getScreenHasPrinter()));
+        result.setD8ScreenHasPrinter(translateToStringYesNoNever(divorceSession.getScreenHasPrinter()));
     }
 
     @AfterMapping
     protected void mapMarriageIsSameSexCouple(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageIsSameSexCouple(translateToStringYesNo(divorceSession.getMarriageIsSameSexCouple()));
+        result.setD8MarriageIsSameSexCouple(translateToStringYesNoNever(divorceSession.getMarriageIsSameSexCouple()));
     }
 
     @AfterMapping
     protected void mapMarriedInUk(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriedInUk(translateToStringYesNo(divorceSession.getMarriedInUk()));
+        result.setD8MarriedInUk(translateToStringYesNoNever(divorceSession.getMarriedInUk()));
     }
 
     @AfterMapping
     protected void mapCertificateInEnglish(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8CertificateInEnglish(translateToStringYesNo(divorceSession.getCertificateInEnglish()));
+        result.setD8CertificateInEnglish(translateToStringYesNoNever(divorceSession.getCertificateInEnglish()));
     }
 
     @AfterMapping
     protected void mapCertifiedTranslation(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8CertifiedTranslation(translateToStringYesNo(divorceSession.getCertifiedTranslation()));
+        result.setD8CertifiedTranslation(translateToStringYesNoNever(divorceSession.getCertifiedTranslation()));
     }
 
     @AfterMapping
     protected void mapPetitionerNameDifferentToMarriageCert(DivorceSession divorceSession,
                                                             @MappingTarget CoreCaseData result) {
         result.setD8PetitionerNameDifferentToMarriageCert(
-            translateToStringYesNo(divorceSession.getPetitionerNameDifferentToMarriageCertificate()));
+            translateToStringYesNoNever(divorceSession.getPetitionerNameDifferentToMarriageCertificate()));
     }
 
     @AfterMapping
     protected void mapPetitionerCorrespondenceUseHomeAddress(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8PetitionerCorrespondenceUseHomeAddress(
-            translateToStringYesNo(divorceSession.getPetitionerCorrespondenceUseHomeAddress()));
+            translateToStringYesNoNever(divorceSession.getPetitionerCorrespondenceUseHomeAddress()));
     }
 
     @AfterMapping
     protected void mapRespondentNameAsOnMarriageCertificate(DivorceSession divorceSession,
                                                             @MappingTarget CoreCaseData result) {
         result.setD8RespondentNameAsOnMarriageCertificate(
-            translateToStringYesNo(divorceSession.getRespondentNameAsOnMarriageCertificate()));
+            translateToStringYesNoNever(divorceSession.getRespondentNameAsOnMarriageCertificate()));
     }
 
     @AfterMapping
     protected void mapRespondentCorrespondenceSendToSol(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8RespondentCorrespondenceSendToSol(
-            translateToStringYesNo(divorceSession.getRespondentCorrespondenceSendToSolicitor()));
+            translateToStringYesNoNever(divorceSession.getRespondentCorrespondenceSendToSolicitor()));
     }
 
     @AfterMapping
     protected void mapRespondentKnowsHomeAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8RespondentKnowsHomeAddress(translateToStringYesNo(divorceSession.getRespondentKnowsHomeAddress()));
+        result.setD8RespondentKnowsHomeAddress(translateToStringYesNoNever(divorceSession.getRespondentKnowsHomeAddress()));
     }
 
     @AfterMapping
     protected void mapRespondentLivesAtLastAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8RespondentLivesAtLastAddress(
-            translateToStringYesNo(divorceSession.getRespondentLivesAtLastAddress()));
+            translateToStringYesNoNever(divorceSession.getRespondentLivesAtLastAddress()));
     }
 
     @AfterMapping
     protected void mapLivingArrangementsLastLivedTogether(DivorceSession divorceSession,
                                                           @MappingTarget CoreCaseData result) {
         result.setD8LivingArrangementsLastLivedTogether(
-            translateToStringYesNo(divorceSession.getLivingArrangementsLastLivedTogether()));
+            translateToStringYesNoNever(divorceSession.getLivingArrangementsLastLivedTogether()));
     }
 
     @AfterMapping
     protected void mapLivingArrangementsLiveTogether(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8LivingArrangementsLiveTogether(
-            translateToStringYesNo(divorceSession.getLivingArrangementsLiveTogether()));
+            translateToStringYesNoNever(divorceSession.getLivingArrangementsLiveTogether()));
     }
 
     @AfterMapping
     protected void mapLegalProceedings(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8LegalProceedings(translateToStringYesNo(divorceSession.getLegalProceedings()));
+        result.setD8LegalProceedings(translateToStringYesNoNever(divorceSession.getLegalProceedings()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionAgreed(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionAgreed(
-            translateToStringYesNo(divorceSession.getReasonForDivorceDesertionAgreed()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionAgreed()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryKnowWhen(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryKnowWhen(
-            translateToStringYesNo(divorceSession.getReasonForDivorceAdulteryKnowWhen()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryKnowWhen()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryWishToName(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryWishToName(
-            translateToStringYesNo(divorceSession.getReasonForDivorceAdulteryWishToName()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryWishToName()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryKnowWhere(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryKnowWhere(
-            translateToStringYesNo(divorceSession.getReasonForDivorceAdulteryKnowWhere()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryKnowWhere()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryIsNamed(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryIsNamed(
-            translateToStringYesNo(divorceSession.getReasonForDivorceAdulteryIsNamed()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryIsNamed()));
     }
 
     @AfterMapping
     protected void mapFinancialOrder(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8FinancialOrder(translateToStringYesNo(divorceSession.getFinancialOrder()));
+        result.setD8FinancialOrder(translateToStringYesNoNever(divorceSession.getFinancialOrder()));
     }
 
     @AfterMapping
     protected void mapHelpWithFeesNeedHelp(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8HelpWithFeesNeedHelp(
-                translateToStringYesNo(divorceSession.getHelpWithFeesNeedHelp()));
+                translateToStringYesNoNever(divorceSession.getHelpWithFeesNeedHelp()));
     }
 
     @AfterMapping
     protected void mapHelpWithFeesAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8HelpWithFeesAppliedForFees(translateToStringYesNo(divorceSession.getHelpWithFeesAppliedForFees()));
+        result.setD8HelpWithFeesAppliedForFees(translateToStringYesNoNever(divorceSession.getHelpWithFeesAppliedForFees()));
     }
 
     @AfterMapping
     protected void mapApplyForDecreeNisi(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setApplyForDecreeNisi(translateToStringYesNo(divorceSession.getApplyForDecreeNisi()));
+        result.setApplyForDecreeNisi(translateToStringYesNoNever(divorceSession.getApplyForDecreeNisi()));
     }
 
     @AfterMapping
     protected void mapDivorceCostsClaim(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8DivorceCostsClaim(translateToStringYesNo(divorceSession.getClaimsCosts()));
+        result.setD8DivorceCostsClaim(translateToStringYesNoNever(divorceSession.getClaimsCosts()));
     }
 
     @AfterMapping
     protected void mapJurisdictionConfidentLegal(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8JurisdictionConfidentLegal(translateToStringYesNo(divorceSession.getJurisdictionConfidentLegal()));
+        result.setD8JurisdictionConfidentLegal(translateToStringYesNoNever(divorceSession.getJurisdictionConfidentLegal()));
     }
 
     @AfterMapping
     protected void mapJurisdictionLastTwelveMonths(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionLastTwelveMonths(
-            translateToStringYesNo(divorceSession.getJurisdictionLastTwelveMonths()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionLastTwelveMonths()));
     }
 
     @AfterMapping
     protected void mapJurisdictionPetitionerDomicile(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionPetitionerDomicile(
-            translateToStringYesNo(divorceSession.getJurisdictionPetitionerDomicile()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionPetitionerDomicile()));
     }
 
     @AfterMapping
     protected void mapJurisdictionPetitionerResidence(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionPetitionerResidence(
-            translateToStringYesNo(divorceSession.getJurisdictionPetitionerResidence()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionPetitionerResidence()));
     }
 
     @AfterMapping
     protected void mapJurisdictionRespondentDomicile(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionRespondentDomicile(
-            translateToStringYesNo(divorceSession.getJurisdictionRespondentDomicile()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionRespondentDomicile()));
     }
 
     @AfterMapping
     protected void mapJurisdictionRespondentResidence(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionRespondentResidence(
-            translateToStringYesNo(divorceSession.getJurisdictionRespondentResidence()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionRespondentResidence()));
     }
 
     @AfterMapping
     protected void mapJurisdictionHabituallyResLast6Months(DivorceSession divorceSession,
                                                            @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionHabituallyResLast6Months(
-            translateToStringYesNo(divorceSession.getJurisdictionLastHabitualResident()));
+            translateToStringYesNoNever(divorceSession.getJurisdictionLastHabitualResident()));
     }
 
     @AfterMapping
     protected void mapResidualJurisdictionEligible(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ResidualJurisdictionEligible(
-            translateToStringYesNo(divorceSession.getResidualJurisdictionEligible()));
+            translateToStringYesNoNever(divorceSession.getResidualJurisdictionEligible()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowAdultery(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowAdultery(
-            translateToStringYesNo(divorceSession.getReasonForDivorceShowAdultery()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowUnreasonableBehavior(DivorceSession divorceSession,
                                                                @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowUnreasonableBehaviour(
-            translateToStringYesNo(divorceSession.getReasonForDivorceShowUnreasonableBehaviour()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowUnreasonableBehaviour()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowTwoYearsSeparation(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowTwoYearsSeparation(
-            translateToStringYesNo(divorceSession.getReasonForDivorceShowTwoYearsSeparation()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowTwoYearsSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowDesertion(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowDesertion(
-            translateToStringYesNo(divorceSession.getReasonForDivorceShowDesertion()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowDesertion()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceLimitReasons(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceLimitReasons(
-            translateToStringYesNo(divorceSession.getReasonForDivorceLimitReasons()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceLimitReasons()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceEnableAdultery(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceEnableAdultery(
-            translateToStringYesNo(divorceSession.getReasonForDivorceEnableAdultery()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceEnableAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionAlright(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionAlright(
-            translateToStringYesNo(divorceSession.getReasonForDivorceDesertionAlright()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionAlright()));
     }
 
     @AfterMapping
     protected void mapClaimsCostsAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ClaimsCostsAppliedForFees(translateToStringYesNo(divorceSession.getClaimsCostsAppliedForFees()));
+        result.setD8ClaimsCostsAppliedForFees(translateToStringYesNoNever(divorceSession.getClaimsCostsAppliedForFees()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceClaimingAdultery(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceClaimingAdultery(
-            translateToStringYesNo(divorceSession.getReasonForDivorceClaimingAdultery()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceClaimingAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationIsSameOrAftr(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationIsSameOrAftr(
-            translateToStringYesNo(divorceSession.getReasonForDivorceSeperationDateIsSameOrAfterLimitDate()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationDateIsSameOrAfterLimitDate()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationInFuture(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationInFuture(
-            translateToStringYesNo(divorceSession.getReasonForDivorceSeperationInFuture()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationInFuture()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionBeforeMarriage(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionBeforeMarriage(
-            translateToStringYesNo(divorceSession.getReasonForDivorceDesertionBeforeMarriage()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionBeforeMarriage()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionInFuture(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionInFuture(
-            translateToStringYesNo(divorceSession.getReasonForDivorceDesertionInFuture()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionInFuture()));
     }
 
     @AfterMapping
     protected void mapMarriageCanDivorce(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageCanDivorce(translateToStringYesNo(divorceSession.getMarriageCanDivorce()));
+        result.setD8MarriageCanDivorce(translateToStringYesNoNever(divorceSession.getMarriageCanDivorce()));
     }
 
     @AfterMapping
     protected void mapMarriageIsFuture(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageIsFuture(translateToStringYesNo(divorceSession.getMarriageIsFuture()));
+        result.setD8MarriageIsFuture(translateToStringYesNoNever(divorceSession.getMarriageIsFuture()));
     }
 
     @AfterMapping
     protected void mapMarriageMoreThan100(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageMoreThan100(translateToStringYesNo(divorceSession.getMarriageMoreThan100()));
+        result.setD8MarriageMoreThan100(translateToStringYesNoNever(divorceSession.getMarriageMoreThan100()));
     }
 
     @AfterMapping
@@ -496,28 +497,28 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapReasonForDivorceHasMarriage(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceHasMarriage(
-            translateToStringYesNo(divorceSession.getReasonForDivorceHasMarriageDate()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceHasMarriageDate()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowFiveYearsSeparation(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowFiveYearsSeparation(
-            translateToStringYesNo(divorceSession.getReasonForDivorceShowFiveYearsSeparation()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowFiveYearsSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceClaiming5YearSeparation(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceClaiming5YearSeparation(
-            translateToStringYesNo(divorceSession.getReasonForDivorceClaiming5YearSeparation()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceClaiming5YearSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationBeforeMarriage(DivorceSession divorceSession,
                                                                @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationBeforeMarriage(
-            translateToStringYesNo(divorceSession.getReasonForDivorceSeperationBeforeMarriage()));
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationBeforeMarriage()));
     }
 
     @AfterMapping
@@ -573,7 +574,7 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapStatementOfTruth(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8StatementOfTruth(translateToStringYesNo(divorceSession.getConfirmPrayer()));
+        result.setD8StatementOfTruth(translateToStringYesNoNever(divorceSession.getConfirmPrayer()));
     }
 
     @AfterMapping
@@ -632,7 +633,7 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapPetitionerConsent(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8PetitionerConsent(translateToStringYesNo(divorceSession.getPetitionerConsent()));
+        result.setD8PetitionerConsent(translateToStringYesNoNever(divorceSession.getPetitionerConsent()));
     }
 
     @AfterMapping
@@ -647,7 +648,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapLivedTogetherMoreTimeThanPermitted(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setLivedTogetherMoreTimeThanPermitted(
-            translateToStringYesNo(divorceSession.getLivedTogetherMoreTimeThanPermitted())
+            translateToStringYesNoNever(divorceSession.getLivedTogetherMoreTimeThanPermitted())
         );
     }
 
@@ -655,7 +656,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapReasonForDivorceAdulterySecondHandInfo(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryAnyInfo2ndHand(
-            translateToStringYesNo(divorceSession.getReasonForDivorceAdulterySecondHandInfo())
+            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulterySecondHandInfo())
         );
     }
 
@@ -663,7 +664,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapLivedApartEntireTime(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setLivedApartEntireTime(
-            translateToStringYesNo(divorceSession.getLivedApartEntireTime())
+            translateToStringYesNoNever(divorceSession.getLivedApartEntireTime())
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorc
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Objects;
 
 import static java.lang.String.join;
@@ -142,7 +141,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapScreenHasRespondentAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasRespondentAddress(translateToStringYesNoNever(divorceSession.getScreenHasRespondentAddress()));
+        result.setD8ScreenHasRespondentAddress(translateToStringYesNoNever(
+            divorceSession.getScreenHasRespondentAddress()));
     }
 
     @AfterMapping
@@ -205,7 +205,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapRespondentKnowsHomeAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8RespondentKnowsHomeAddress(translateToStringYesNoNever(divorceSession.getRespondentKnowsHomeAddress()));
+        result.setD8RespondentKnowsHomeAddress(
+            translateToStringYesNoNever(divorceSession.getRespondentKnowsHomeAddress()));
     }
 
     @AfterMapping
@@ -281,7 +282,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapHelpWithFeesAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8HelpWithFeesAppliedForFees(translateToStringYesNoNever(divorceSession.getHelpWithFeesAppliedForFees()));
+        result.setD8HelpWithFeesAppliedForFees(
+            translateToStringYesNoNever(divorceSession.getHelpWithFeesAppliedForFees()));
     }
 
     @AfterMapping
@@ -296,7 +298,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapJurisdictionConfidentLegal(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8JurisdictionConfidentLegal(translateToStringYesNoNever(divorceSession.getJurisdictionConfidentLegal()));
+        result.setD8JurisdictionConfidentLegal(
+            translateToStringYesNoNever(divorceSession.getJurisdictionConfidentLegal()));
     }
 
     @AfterMapping
@@ -394,7 +397,8 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapClaimsCostsAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ClaimsCostsAppliedForFees(translateToStringYesNoNever(divorceSession.getClaimsCostsAppliedForFees()));
+        result.setD8ClaimsCostsAppliedForFees(
+            translateToStringYesNoNever(divorceSession.getClaimsCostsAppliedForFees()));
     }
 
     @AfterMapping

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -26,7 +26,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNo;
 
-@Mapper(componentModel = "spring", uses = DocumentCollectionCCDFormatMapper.class,
+@Mapper(componentModel = "spring", uses = {
+    DocumentCollectionCCDFormatMapper.class, StringCollectionCCDFormatMapper.class},
     unmappedTargetPolicy = ReportingPolicy.IGNORE)
 @SuppressWarnings({"PMD.GodClass", "common-java:DuplicatedBlocks"})
 public abstract class DivorceCaseToCCDMapper {
@@ -114,6 +115,8 @@ public abstract class DivorceCaseToCCDMapper {
         target = "reasonForDivorceDecisionDate")
     @Mapping(source = "reasonForDivorceLivingApartDate", dateFormat = SIMPLE_DATE_FORMAT,
         target = "reasonForDivorceLivingApartDate")
+    @Mapping(source = "previousCaseId", target = "previousCaseId")
+    @Mapping(source = "previousReasonsForDivorce", target = "previousReasonsForDivorce")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 
     @BeforeMapping

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
-import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToStringYesNoNever;
+import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.translateToAnswer;
 
 @Mapper(componentModel = "spring", uses = {
     DocumentCollectionCCDFormatMapper.class, StringCollectionCCDFormatMapper.class},
@@ -136,319 +136,319 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapScreenHasMarriageBroken(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasMarriageBroken(translateToStringYesNoNever(divorceSession.getScreenHasMarriageBroken()));
+        result.setD8ScreenHasMarriageBroken(translateToAnswer(divorceSession.getScreenHasMarriageBroken()));
     }
 
     @AfterMapping
     protected void mapScreenHasRespondentAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasRespondentAddress(translateToStringYesNoNever(
+        result.setD8ScreenHasRespondentAddress(translateToAnswer(
             divorceSession.getScreenHasRespondentAddress()));
     }
 
     @AfterMapping
     protected void mapScreenHasMarriageCert(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasMarriageCert(translateToStringYesNoNever(divorceSession.getScreenHasMarriageCert()));
+        result.setD8ScreenHasMarriageCert(translateToAnswer(divorceSession.getScreenHasMarriageCert()));
     }
 
     @AfterMapping
     protected void mapScreenHasPrinter(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8ScreenHasPrinter(translateToStringYesNoNever(divorceSession.getScreenHasPrinter()));
+        result.setD8ScreenHasPrinter(translateToAnswer(divorceSession.getScreenHasPrinter()));
     }
 
     @AfterMapping
     protected void mapMarriageIsSameSexCouple(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageIsSameSexCouple(translateToStringYesNoNever(divorceSession.getMarriageIsSameSexCouple()));
+        result.setD8MarriageIsSameSexCouple(translateToAnswer(divorceSession.getMarriageIsSameSexCouple()));
     }
 
     @AfterMapping
     protected void mapMarriedInUk(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriedInUk(translateToStringYesNoNever(divorceSession.getMarriedInUk()));
+        result.setD8MarriedInUk(translateToAnswer(divorceSession.getMarriedInUk()));
     }
 
     @AfterMapping
     protected void mapCertificateInEnglish(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8CertificateInEnglish(translateToStringYesNoNever(divorceSession.getCertificateInEnglish()));
+        result.setD8CertificateInEnglish(translateToAnswer(divorceSession.getCertificateInEnglish()));
     }
 
     @AfterMapping
     protected void mapCertifiedTranslation(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8CertifiedTranslation(translateToStringYesNoNever(divorceSession.getCertifiedTranslation()));
+        result.setD8CertifiedTranslation(translateToAnswer(divorceSession.getCertifiedTranslation()));
     }
 
     @AfterMapping
     protected void mapPetitionerNameDifferentToMarriageCert(DivorceSession divorceSession,
                                                             @MappingTarget CoreCaseData result) {
         result.setD8PetitionerNameDifferentToMarriageCert(
-            translateToStringYesNoNever(divorceSession.getPetitionerNameDifferentToMarriageCertificate()));
+            translateToAnswer(divorceSession.getPetitionerNameDifferentToMarriageCertificate()));
     }
 
     @AfterMapping
     protected void mapPetitionerCorrespondenceUseHomeAddress(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8PetitionerCorrespondenceUseHomeAddress(
-            translateToStringYesNoNever(divorceSession.getPetitionerCorrespondenceUseHomeAddress()));
+            translateToAnswer(divorceSession.getPetitionerCorrespondenceUseHomeAddress()));
     }
 
     @AfterMapping
     protected void mapRespondentNameAsOnMarriageCertificate(DivorceSession divorceSession,
                                                             @MappingTarget CoreCaseData result) {
         result.setD8RespondentNameAsOnMarriageCertificate(
-            translateToStringYesNoNever(divorceSession.getRespondentNameAsOnMarriageCertificate()));
+            translateToAnswer(divorceSession.getRespondentNameAsOnMarriageCertificate()));
     }
 
     @AfterMapping
     protected void mapRespondentCorrespondenceSendToSol(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8RespondentCorrespondenceSendToSol(
-            translateToStringYesNoNever(divorceSession.getRespondentCorrespondenceSendToSolicitor()));
+            translateToAnswer(divorceSession.getRespondentCorrespondenceSendToSolicitor()));
     }
 
     @AfterMapping
     protected void mapRespondentKnowsHomeAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8RespondentKnowsHomeAddress(
-            translateToStringYesNoNever(divorceSession.getRespondentKnowsHomeAddress()));
+            translateToAnswer(divorceSession.getRespondentKnowsHomeAddress()));
     }
 
     @AfterMapping
     protected void mapRespondentLivesAtLastAddress(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8RespondentLivesAtLastAddress(
-            translateToStringYesNoNever(divorceSession.getRespondentLivesAtLastAddress()));
+            translateToAnswer(divorceSession.getRespondentLivesAtLastAddress()));
     }
 
     @AfterMapping
     protected void mapLivingArrangementsLastLivedTogether(DivorceSession divorceSession,
                                                           @MappingTarget CoreCaseData result) {
         result.setD8LivingArrangementsLastLivedTogether(
-            translateToStringYesNoNever(divorceSession.getLivingArrangementsLastLivedTogether()));
+            translateToAnswer(divorceSession.getLivingArrangementsLastLivedTogether()));
     }
 
     @AfterMapping
     protected void mapLivingArrangementsLiveTogether(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8LivingArrangementsLiveTogether(
-            translateToStringYesNoNever(divorceSession.getLivingArrangementsLiveTogether()));
+            translateToAnswer(divorceSession.getLivingArrangementsLiveTogether()));
     }
 
     @AfterMapping
     protected void mapLegalProceedings(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8LegalProceedings(translateToStringYesNoNever(divorceSession.getLegalProceedings()));
+        result.setD8LegalProceedings(translateToAnswer(divorceSession.getLegalProceedings()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionAgreed(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionAgreed(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionAgreed()));
+            translateToAnswer(divorceSession.getReasonForDivorceDesertionAgreed()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryKnowWhen(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryKnowWhen(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryKnowWhen()));
+            translateToAnswer(divorceSession.getReasonForDivorceAdulteryKnowWhen()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryWishToName(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryWishToName(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryWishToName()));
+            translateToAnswer(divorceSession.getReasonForDivorceAdulteryWishToName()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryKnowWhere(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryKnowWhere(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryKnowWhere()));
+            translateToAnswer(divorceSession.getReasonForDivorceAdulteryKnowWhere()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceAdulteryIsNamed(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryIsNamed(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulteryIsNamed()));
+            translateToAnswer(divorceSession.getReasonForDivorceAdulteryIsNamed()));
     }
 
     @AfterMapping
     protected void mapFinancialOrder(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8FinancialOrder(translateToStringYesNoNever(divorceSession.getFinancialOrder()));
+        result.setD8FinancialOrder(translateToAnswer(divorceSession.getFinancialOrder()));
     }
 
     @AfterMapping
     protected void mapHelpWithFeesNeedHelp(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8HelpWithFeesNeedHelp(
-                translateToStringYesNoNever(divorceSession.getHelpWithFeesNeedHelp()));
+                translateToAnswer(divorceSession.getHelpWithFeesNeedHelp()));
     }
 
     @AfterMapping
     protected void mapHelpWithFeesAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8HelpWithFeesAppliedForFees(
-            translateToStringYesNoNever(divorceSession.getHelpWithFeesAppliedForFees()));
+            translateToAnswer(divorceSession.getHelpWithFeesAppliedForFees()));
     }
 
     @AfterMapping
     protected void mapApplyForDecreeNisi(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setApplyForDecreeNisi(translateToStringYesNoNever(divorceSession.getApplyForDecreeNisi()));
+        result.setApplyForDecreeNisi(translateToAnswer(divorceSession.getApplyForDecreeNisi()));
     }
 
     @AfterMapping
     protected void mapDivorceCostsClaim(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8DivorceCostsClaim(translateToStringYesNoNever(divorceSession.getClaimsCosts()));
+        result.setD8DivorceCostsClaim(translateToAnswer(divorceSession.getClaimsCosts()));
     }
 
     @AfterMapping
     protected void mapJurisdictionConfidentLegal(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionConfidentLegal(
-            translateToStringYesNoNever(divorceSession.getJurisdictionConfidentLegal()));
+            translateToAnswer(divorceSession.getJurisdictionConfidentLegal()));
     }
 
     @AfterMapping
     protected void mapJurisdictionLastTwelveMonths(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionLastTwelveMonths(
-            translateToStringYesNoNever(divorceSession.getJurisdictionLastTwelveMonths()));
+            translateToAnswer(divorceSession.getJurisdictionLastTwelveMonths()));
     }
 
     @AfterMapping
     protected void mapJurisdictionPetitionerDomicile(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionPetitionerDomicile(
-            translateToStringYesNoNever(divorceSession.getJurisdictionPetitionerDomicile()));
+            translateToAnswer(divorceSession.getJurisdictionPetitionerDomicile()));
     }
 
     @AfterMapping
     protected void mapJurisdictionPetitionerResidence(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionPetitionerResidence(
-            translateToStringYesNoNever(divorceSession.getJurisdictionPetitionerResidence()));
+            translateToAnswer(divorceSession.getJurisdictionPetitionerResidence()));
     }
 
     @AfterMapping
     protected void mapJurisdictionRespondentDomicile(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionRespondentDomicile(
-            translateToStringYesNoNever(divorceSession.getJurisdictionRespondentDomicile()));
+            translateToAnswer(divorceSession.getJurisdictionRespondentDomicile()));
     }
 
     @AfterMapping
     protected void mapJurisdictionRespondentResidence(DivorceSession divorceSession,
                                                       @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionRespondentResidence(
-            translateToStringYesNoNever(divorceSession.getJurisdictionRespondentResidence()));
+            translateToAnswer(divorceSession.getJurisdictionRespondentResidence()));
     }
 
     @AfterMapping
     protected void mapJurisdictionHabituallyResLast6Months(DivorceSession divorceSession,
                                                            @MappingTarget CoreCaseData result) {
         result.setD8JurisdictionHabituallyResLast6Months(
-            translateToStringYesNoNever(divorceSession.getJurisdictionLastHabitualResident()));
+            translateToAnswer(divorceSession.getJurisdictionLastHabitualResident()));
     }
 
     @AfterMapping
     protected void mapResidualJurisdictionEligible(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ResidualJurisdictionEligible(
-            translateToStringYesNoNever(divorceSession.getResidualJurisdictionEligible()));
+            translateToAnswer(divorceSession.getResidualJurisdictionEligible()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowAdultery(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowAdultery(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowAdultery()));
+            translateToAnswer(divorceSession.getReasonForDivorceShowAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowUnreasonableBehavior(DivorceSession divorceSession,
                                                                @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowUnreasonableBehaviour(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowUnreasonableBehaviour()));
+            translateToAnswer(divorceSession.getReasonForDivorceShowUnreasonableBehaviour()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowTwoYearsSeparation(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowTwoYearsSeparation(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowTwoYearsSeparation()));
+            translateToAnswer(divorceSession.getReasonForDivorceShowTwoYearsSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowDesertion(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowDesertion(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowDesertion()));
+            translateToAnswer(divorceSession.getReasonForDivorceShowDesertion()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceLimitReasons(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceLimitReasons(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceLimitReasons()));
+            translateToAnswer(divorceSession.getReasonForDivorceLimitReasons()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceEnableAdultery(DivorceSession divorceSession,
                                                      @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceEnableAdultery(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceEnableAdultery()));
+            translateToAnswer(divorceSession.getReasonForDivorceEnableAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionAlright(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionAlright(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionAlright()));
+            translateToAnswer(divorceSession.getReasonForDivorceDesertionAlright()));
     }
 
     @AfterMapping
     protected void mapClaimsCostsAppliedForFees(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ClaimsCostsAppliedForFees(
-            translateToStringYesNoNever(divorceSession.getClaimsCostsAppliedForFees()));
+            translateToAnswer(divorceSession.getClaimsCostsAppliedForFees()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceClaimingAdultery(DivorceSession divorceSession,
                                                        @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceClaimingAdultery(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceClaimingAdultery()));
+            translateToAnswer(divorceSession.getReasonForDivorceClaimingAdultery()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationIsSameOrAftr(DivorceSession divorceSession,
                                                              @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationIsSameOrAftr(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationDateIsSameOrAfterLimitDate()));
+            translateToAnswer(divorceSession.getReasonForDivorceSeperationDateIsSameOrAfterLimitDate()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationInFuture(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationInFuture(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationInFuture()));
+            translateToAnswer(divorceSession.getReasonForDivorceSeperationInFuture()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionBeforeMarriage(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionBeforeMarriage(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionBeforeMarriage()));
+            translateToAnswer(divorceSession.getReasonForDivorceDesertionBeforeMarriage()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceDesertionInFuture(DivorceSession divorceSession,
                                                         @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceDesertionInFuture(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceDesertionInFuture()));
+            translateToAnswer(divorceSession.getReasonForDivorceDesertionInFuture()));
     }
 
     @AfterMapping
     protected void mapMarriageCanDivorce(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageCanDivorce(translateToStringYesNoNever(divorceSession.getMarriageCanDivorce()));
+        result.setD8MarriageCanDivorce(translateToAnswer(divorceSession.getMarriageCanDivorce()));
     }
 
     @AfterMapping
     protected void mapMarriageIsFuture(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageIsFuture(translateToStringYesNoNever(divorceSession.getMarriageIsFuture()));
+        result.setD8MarriageIsFuture(translateToAnswer(divorceSession.getMarriageIsFuture()));
     }
 
     @AfterMapping
     protected void mapMarriageMoreThan100(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8MarriageMoreThan100(translateToStringYesNoNever(divorceSession.getMarriageMoreThan100()));
+        result.setD8MarriageMoreThan100(translateToAnswer(divorceSession.getMarriageMoreThan100()));
     }
 
     @AfterMapping
@@ -501,28 +501,28 @@ public abstract class DivorceCaseToCCDMapper {
     @AfterMapping
     protected void mapReasonForDivorceHasMarriage(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceHasMarriage(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceHasMarriageDate()));
+            translateToAnswer(divorceSession.getReasonForDivorceHasMarriageDate()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceShowFiveYearsSeparation(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceShowFiveYearsSeparation(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceShowFiveYearsSeparation()));
+            translateToAnswer(divorceSession.getReasonForDivorceShowFiveYearsSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceClaiming5YearSeparation(DivorceSession divorceSession,
                                                               @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceClaiming5YearSeparation(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceClaiming5YearSeparation()));
+            translateToAnswer(divorceSession.getReasonForDivorceClaiming5YearSeparation()));
     }
 
     @AfterMapping
     protected void mapReasonForDivorceSeperationBeforeMarriage(DivorceSession divorceSession,
                                                                @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceSeperationBeforeMarriage(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceSeperationBeforeMarriage()));
+            translateToAnswer(divorceSession.getReasonForDivorceSeperationBeforeMarriage()));
     }
 
     @AfterMapping
@@ -578,7 +578,7 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapStatementOfTruth(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8StatementOfTruth(translateToStringYesNoNever(divorceSession.getConfirmPrayer()));
+        result.setD8StatementOfTruth(translateToAnswer(divorceSession.getConfirmPrayer()));
     }
 
     @AfterMapping
@@ -637,7 +637,7 @@ public abstract class DivorceCaseToCCDMapper {
 
     @AfterMapping
     protected void mapPetitionerConsent(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
-        result.setD8PetitionerConsent(translateToStringYesNoNever(divorceSession.getPetitionerConsent()));
+        result.setD8PetitionerConsent(translateToAnswer(divorceSession.getPetitionerConsent()));
     }
 
     @AfterMapping
@@ -652,7 +652,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapLivedTogetherMoreTimeThanPermitted(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setLivedTogetherMoreTimeThanPermitted(
-            translateToStringYesNoNever(divorceSession.getLivedTogetherMoreTimeThanPermitted())
+            translateToAnswer(divorceSession.getLivedTogetherMoreTimeThanPermitted())
         );
     }
 
@@ -660,7 +660,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapReasonForDivorceAdulterySecondHandInfo(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setD8ReasonForDivorceAdulteryAnyInfo2ndHand(
-            translateToStringYesNoNever(divorceSession.getReasonForDivorceAdulterySecondHandInfo())
+            translateToAnswer(divorceSession.getReasonForDivorceAdulterySecondHandInfo())
         );
     }
 
@@ -668,7 +668,7 @@ public abstract class DivorceCaseToCCDMapper {
     protected void mapLivedApartEntireTime(DivorceSession divorceSession,
                                                          @MappingTarget CoreCaseData result) {
         result.setLivedApartEntireTime(
-            translateToStringYesNoNever(divorceSession.getLivedApartEntireTime())
+            translateToAnswer(divorceSession.getLivedApartEntireTime())
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -135,6 +135,17 @@ public abstract class DivorceCaseToCCDMapper {
     }
 
     @AfterMapping
+    protected void mapPreviousCaseData(DivorceSession divorceSession,
+                                     @MappingTarget CoreCaseData caseData) {
+        if (divorceSession.getPreviousCaseId() == null) {
+            caseData.setPreviousCaseId(null);
+        }
+        if (divorceSession.getPreviousReasonsForDivorce() == null) {
+            caseData.setPreviousReasonsForDivorce(null);
+        }
+    }
+
+    @AfterMapping
     protected void mapScreenHasMarriageBroken(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
         result.setD8ScreenHasMarriageBroken(translateToAnswer(divorceSession.getScreenHasMarriageBroken()));
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnCaseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnCaseMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
@@ -44,6 +45,17 @@ public abstract class DivorceCaseToDnCaseMapper {
     @AfterMapping
     protected void mapDnApplicationSubmittedDate(DivorceSession divorceSession, @MappingTarget DnCaseData result) {
         result.setDnApplicationSubmittedDate(LocalDate.now().format(DateTimeFormatter.ofPattern(SIMPLE_DATE_FORMAT)));
+    }
+
+    @AfterMapping
+    protected void mapPreviousCaseData(DivorceSession divorceSession,
+                                       @MappingTarget CoreCaseData caseData) {
+        if (divorceSession.getPreviousCaseId() == null) {
+            caseData.setPreviousCaseId(null);
+        }
+        if (divorceSession.getPreviousReasonsForDivorce() == null) {
+            caseData.setPreviousReasonsForDivorce(null);
+        }
     }
 
     @AfterMapping

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
@@ -7,10 +7,10 @@ import java.util.Objects;
 
 public class MappingCommons {
 
-    private final static String NEVER = "NEVER";
-
     private MappingCommons() {
     }
+
+    private static final String NEVER = "NEVER";
 
     public static final String SIMPLE_DATE_FORMAT = "yyyy-MM-dd";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
@@ -7,14 +7,19 @@ import java.util.Objects;
 
 public class MappingCommons {
 
+    private final static String NEVER = "NEVER";
+
     private MappingCommons() {
     }
 
     public static final String SIMPLE_DATE_FORMAT = "yyyy-MM-dd";
 
-    public static String translateToStringYesNo(final String value) {
+    public static String translateToStringYesNoNever(final String value) {
         if (Objects.isNull(value)) {
             return null;
+        }
+        if (value.equalsIgnoreCase(NEVER)) {
+            return NEVER;
         }
         return BooleanUtils.toStringYesNo(BooleanUtils.toBoolean(value)).toUpperCase(Locale.ENGLISH);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/MappingCommons.java
@@ -14,7 +14,7 @@ public class MappingCommons {
 
     public static final String SIMPLE_DATE_FORMAT = "yyyy-MM-dd";
 
-    public static String translateToStringYesNoNever(final String value) {
+    public static String translateToAnswer(final String value) {
         if (Objects.isNull(value)) {
             return null;
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
@@ -4,16 +4,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public class StringCollectionCCDFormatMapper {
 
-    @SuppressWarnings(value = "null")
     public List<CollectionMember> map(List<String> collection) {
         if (collection == null) {
-            return null;
+            return new ArrayList<>();
         }
         return collection.stream()
             .map(value -> {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
@@ -4,16 +4,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public class StringCollectionCCDFormatMapper {
 
+    @SuppressWarnings(value = "null")
     public List<CollectionMember> map(List<String> collection) {
         if (collection == null) {
-            return new ArrayList<>();
+            return null;
         }
         return collection.stream()
             .map(value -> {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public abstract class StringCollectionCCDFormatMapper {
+
+    public List<CollectionMember> map(List<String> collection) {
+        if (collection == null || collection.isEmpty()) {
+            return null;
+        }
+        return collection.stream()
+            .map((value) -> {
+                final CollectionMember<String> entry = new CollectionMember<>();
+                entry.setValue(value);
+                return entry;
+            })
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionCCDFormatMapper.java
@@ -4,18 +4,19 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public abstract class StringCollectionCCDFormatMapper {
+public class StringCollectionCCDFormatMapper {
 
     public List<CollectionMember> map(List<String> collection) {
-        if (collection == null || collection.isEmpty()) {
-            return null;
+        if (collection == null) {
+            return new ArrayList<>();
         }
         return collection.stream()
-            .map((value) -> {
+            .map(value -> {
                 final CollectionMember<String> entry = new CollectionMember<>();
                 entry.setValue(value);
                 return entry;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
@@ -4,16 +4,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public class StringCollectionDivorceFormatMapper {
 
+    @SuppressWarnings(value = "null")
     public List<String> map(List<CollectionMember> collection) {
         if (collection == null) {
-            return new ArrayList<>();
+            return null;
         }
         return collection.stream()
             .map(value -> (String) value.getValue())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
@@ -4,18 +4,19 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public abstract class StringCollectionDivorceFormatMapper {
+public class StringCollectionDivorceFormatMapper {
 
     public List<String> map(List<CollectionMember> collection) {
-        if (collection == null || collection.isEmpty()) {
-            return null;
+        if (collection == null) {
+            return new ArrayList<>();
         }
         return collection.stream()
-            .map((value) -> (String) value.getValue())
+            .map(value -> (String) value.getValue())
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public abstract class StringCollectionDivorceFormatMapper {
+
+    public List<String> map(List<CollectionMember> collection) {
+        if (collection == null || collection.isEmpty()) {
+            return null;
+        }
+        return collection.stream()
+            .map((value) -> (String) value.getValue())
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/StringCollectionDivorceFormatMapper.java
@@ -4,16 +4,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public class StringCollectionDivorceFormatMapper {
 
-    @SuppressWarnings(value = "null")
     public List<String> map(List<CollectionMember> collection) {
         if (collection == null) {
-            return null;
+            return new ArrayList<>();
         }
         return collection.stream()
             .map(value -> (String) value.getValue())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/TranslateAnswerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/TranslateAnswerUTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class YesNoNeverAnswerUTest {
+public class TranslateAnswerUTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -18,10 +18,10 @@ public class YesNoNeverAnswerUTest {
         String yes = "yes";
 
         // when
-        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(yes, YesNoNeverAnswer.class);
+        TranslateAnswer translateAnswer = objectMapper.convertValue(yes, TranslateAnswer.class);
 
         // then
-        assertEquals(YesNoNeverAnswer.YES, yesNoNeverAnswer);
+        assertEquals(TranslateAnswer.YES, translateAnswer);
     }
 
     @Test
@@ -31,10 +31,10 @@ public class YesNoNeverAnswerUTest {
         String no = "no";
 
         // when
-        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(no, YesNoNeverAnswer.class);
+        TranslateAnswer translateAnswer = objectMapper.convertValue(no, TranslateAnswer.class);
 
         // then
-        assertEquals(YesNoNeverAnswer.NO, yesNoNeverAnswer);
+        assertEquals(TranslateAnswer.NO, translateAnswer);
     }
 
     @Test
@@ -44,10 +44,10 @@ public class YesNoNeverAnswerUTest {
         String no = "never";
 
         // when
-        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(no, YesNoNeverAnswer.class);
+        TranslateAnswer translateAnswer = objectMapper.convertValue(no, TranslateAnswer.class);
 
         // then
-        assertEquals(YesNoNeverAnswer.NEVER, yesNoNeverAnswer);
+        assertEquals(TranslateAnswer.NEVER, translateAnswer);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class YesNoNeverAnswerUTest {
 
         // when
         try {
-            objectMapper.convertValue(maybe, YesNoNeverAnswer.class);
+            objectMapper.convertValue(maybe, TranslateAnswer.class);
         } catch (IllegalArgumentException e) {
             exception = e;
         }
@@ -69,7 +69,7 @@ public class YesNoNeverAnswerUTest {
         assertNotNull(exception);
         String exceptionMessage = exception.getMessage();
 
-        for (YesNoNeverAnswer answer : YesNoNeverAnswer.values()) {
+        for (TranslateAnswer answer : TranslateAnswer.values()) {
             assertTrue(exceptionMessage.contains(answer.name()));
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/YesNoNeverAnswerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/YesNoNeverAnswerUTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class YesNoAnswerUTest {
+public class YesNoNeverAnswerUTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -18,10 +18,10 @@ public class YesNoAnswerUTest {
         String yes = "yes";
 
         // when
-        YesNoAnswer yesNoAnswer = objectMapper.convertValue(yes, YesNoAnswer.class);
+        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(yes, YesNoNeverAnswer.class);
 
         // then
-        assertEquals(YesNoAnswer.YES, yesNoAnswer);
+        assertEquals(YesNoNeverAnswer.YES, yesNoNeverAnswer);
     }
 
     @Test
@@ -31,10 +31,23 @@ public class YesNoAnswerUTest {
         String no = "no";
 
         // when
-        YesNoAnswer yesNoAnswer = objectMapper.convertValue(no, YesNoAnswer.class);
+        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(no, YesNoNeverAnswer.class);
 
         // then
-        assertEquals(YesNoAnswer.NO, yesNoAnswer);
+        assertEquals(YesNoNeverAnswer.NO, yesNoNeverAnswer);
+    }
+
+    @Test
+    public void fromInput_converts_never_successfully() {
+
+        // given
+        String no = "never";
+
+        // when
+        YesNoNeverAnswer yesNoNeverAnswer = objectMapper.convertValue(no, YesNoNeverAnswer.class);
+
+        // then
+        assertEquals(YesNoNeverAnswer.NEVER, yesNoNeverAnswer);
     }
 
     @Test
@@ -47,7 +60,7 @@ public class YesNoAnswerUTest {
 
         // when
         try {
-            objectMapper.convertValue(maybe, YesNoAnswer.class);
+            objectMapper.convertValue(maybe, YesNoNeverAnswer.class);
         } catch (IllegalArgumentException e) {
             exception = e;
         }
@@ -56,7 +69,7 @@ public class YesNoAnswerUTest {
         assertNotNull(exception);
         String exceptionMessage = exception.getMessage();
 
-        for (YesNoAnswer answer : YesNoAnswer.values()) {
+        for (YesNoNeverAnswer answer : YesNoNeverAnswer.values()) {
             assertTrue(exceptionMessage.contains(answer.name()));
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AmendPetitionSubmissionUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/AmendPetitionSubmissionUTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.divorcetoccdformat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceApplication;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.DivorceCaseToCCDMapper;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = CaseFormatterServiceApplication.class)
+public class AmendPetitionSubmissionUTest {
+
+    @Autowired
+    private DivorceCaseToCCDMapper mapper;
+
+    @Test
+    public void shouldMapAllAndTransformAllFieldsForD8DocumentGenerated() throws URISyntaxException, IOException {
+
+        CoreCaseData expectedCoreCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json",
+                CoreCaseData.class);
+        expectedCoreCaseData.setCreatedDate(LocalDate.now().format(ofPattern("yyyy-MM-dd")));
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/amend-petition-session-submit.json",
+                    DivorceSession.class);
+
+        CoreCaseData actualCoreCaseData = mapper.divorceCaseDataToCourtCaseData(divorceSession);
+
+        assertThat(actualCoreCaseData, samePropertyValuesAs(expectedCoreCaseData));
+    }
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/addressabroadcase.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/addressabroadcase.json
@@ -92,7 +92,7 @@
     "D8RespondentLivesAtLastAddress" : "NO",
     "D8RejectRespondentAddress" : null,
     "D8LivingArrangementsTogetherSeparated" : null,
-    "D8LivingArrangementsLastLivedTogether" : "NO",
+    "D8LivingArrangementsLastLivedTogether" : "NEVER",
     "D8LivingArrangementsLiveTogether" : "NO",
     "D8LivingArrangementsLastLivedTogethAddr": {
         "addressType": "manual",

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-abroad.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-abroad.json
@@ -93,7 +93,7 @@
         ]
     },
     "livingArrangementsLiveTogether":"No",
-    "livingArrangementsLastLivedTogether":"No",
+    "livingArrangementsLastLivedTogether":"Never",
     "livingArrangementsLastLivedTogetherAddress":{
         "addressType":"manual",
         "postcode":null,

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
@@ -7,9 +7,8 @@
     "D8ScreenHasMarriageCert" : "YES",
     "D8ScreenHasPrinter" : "YES",
     "D8DivorceWho" : "husband",
-    "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
-    "D8MarriedInUk" : null,
+    "D8MarriedInUk" : "YES",
     "D8CertificateInEnglish" : null,
     "D8CertifiedTranslation" : null,
     "D8MarriagePlaceOfMarriage" : null,
@@ -65,34 +64,24 @@
     "D8LegalProceedings" : "YES",
     "D8LegalProceedingsRelated" : [ "children" ],
     "D8LegalProceedingsDetails" : "The legal proceeding details",
-    "D8ReasonForDivorce" : "adultery",
-    "D8DerivedStatementOfCase" : "On a washing machine.\nSome time ago.\nIt hurts inside.",
+    "D8ReasonForDivorce" : "unreasonable-behaviour",
+    "D8DerivedStatementOfCase" : "My wife is having an affair this week.",
     "D8RejectStatementOfCase" : null,
-    "D8ReasonForDivorceBehaviourDetails" : null,
+    "D8ReasonForDivorceBehaviourDetails" : "My wife is having an affair this week.",
     "D8ReasonForDivorceDesertionDate" : null,
     "D8ReasonForDivorceDesertionAgreed" : null,
     "D8ReasonForDivorceDesertionDetails" : null,
     "D8ReasonForDivorceSeperationDate" : null,
-    "D8ReasonForDivorceAdultery3rdPartyFName" : "Jennifer",
-    "D8ReasonForDivorceAdultery3rdPartyLName" : "Lawrence",
-    "D8ReasonForDivorceAdulteryDetails" : "It hurts inside.",
-    "D8ReasonForDivorceAdulteryKnowWhen" : "YES",
-    "D8ReasonForDivorceAdulteryWishToName" : "YES",
-    "D8ReasonForDivorceAdulteryKnowWhere" : "YES",
-    "D8ReasonForDivorceAdulteryWhereDetails" : "On a washing machine.",
-    "D8ReasonForDivorceAdulteryWhenDetails" : "Some time ago.",
-    "D8ReasonForDivorceAdulteryIsNamed" : "YES",
-    "D8ReasonForDivorceAdultery3rdAddress": {
-        "addressType": "manual",
-        "address": [
-            "Headquarters 1120 N Street Sacramento 916-654-5266\t",
-            "P.O. Box 942873 Sacramento, CA 94273-0001"
-        ],
-        "addressConfirmed": "true",
-        "addressAbroad": "Headquarters 1120 N Street Sacramento 916-654-5266\t\r\nP.O. Box 942873 Sacramento, CA 94273-0001\r\n",
-        "url": "/about-divorce/reason-for-divorce/adultery/co-respondent-address"
-    },
-    "D8DerivedReasonForDivorceAdultery3rdAddr" : "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+    "D8ReasonForDivorceAdultery3rdPartyFName" : null,
+    "D8ReasonForDivorceAdultery3rdPartyLName" : null,
+    "D8ReasonForDivorceAdulteryDetails" : null,
+    "D8ReasonForDivorceAdulteryKnowWhen" : null,
+    "D8ReasonForDivorceAdulteryWishToName" : null,
+    "D8ReasonForDivorceAdulteryKnowWhere" : null,
+    "D8ReasonForDivorceAdulteryWhereDetails" : null,
+    "D8ReasonForDivorceAdulteryWhenDetails" : null,
+    "D8ReasonForDivorceAdulteryIsNamed" : "NO",
+    "D8ReasonForDivorceAdultery3rdAddress" : null,
     "D8FinancialOrder" : "YES",
     "D8FinancialOrderFor" : [ "petitioner", "children" ],
     "D8HelpWithFeesNeedHelp" : "YES",
@@ -101,7 +90,7 @@
     "D8PaymentMethod" : null,
     "D8DivorceCostsClaim" : "YES",
     "D8DivorceIsNamed" : null,
-    "D8DivorceClaimFrom" : [ "respondent", "correspondent" ],
+    "D8DivorceClaimFrom" : [ "respondent" ],
     "D8JurisdictionConfidentLegal" : "YES",
     "D8JurisdictionConnection" : [ "A", "C" ],
     "D8JurisdictionLastTwelveMonths" : null,
@@ -112,42 +101,11 @@
     "D8JurisdictionHabituallyResLast6Months" : null,
     "D8ResidualJurisdictionEligible" : null,
     "Payments" : null,
-    "D8DocumentsUploaded" : [
-        {
-            "id" : null,
-            "value" : {
-                "DocumentType" : "other",
-                "DocumentLink" : {
-                    "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
-                    "document_binary_url" : null,
-                    "document_filename" : null
-                },
-                "DocumentDateAdded" : "2017-12-11",
-                "DocumentComment" : "",
-                "DocumentFileName" : "govuklogo.png",
-                "DocumentEmailContent" : ""
-            }
-        },
-        {
-            "id" : null,
-            "value" : {
-                "DocumentType": "other",
-                "DocumentLink" : {
-                    "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683",
-                    "document_binary_url" : null,
-                    "document_filename" : null
-                },
-                "DocumentDateAdded": "2017-12-11",
-                "DocumentComment": "",
-                "DocumentFileName": "d8-eng.pdf",
-                "DocumentEmailContent": ""
-            }
-        }
-    ],
+    "D8DocumentsUploaded" : null,
     "D8RejectDocumentsUploaded" : null,
-    "D8StatementOfTruth" : null,
+    "D8StatementOfTruth" : "YES",
     "D8SolicitorReference" : null,
-    "D8DivorceUnit" : "westMidlands",
+    "D8DivorceUnit" : "eastMidlands",
     "D8ReasonForDivorceShowAdultery" : "YES",
     "D8ReasonForDivorceShowUnreasonableBehavi" : "YES",
     "D8ReasonForDivorceShowTwoYearsSeparation" : "YES",
@@ -156,7 +114,7 @@
     "D8ReasonForDivorceEnableAdultery" : "YES",
     "D8ReasonForDivorceDesertionAlright" : null,
     "D8ClaimsCostsAppliedForFees" : "YES",
-    "D8ReasonForDivorceClaimingAdultery" : "YES",
+    "D8ReasonForDivorceClaimingAdultery" : "NO",
     "D8ReasonForDivorceSeperationIsSameOrAftr" : null,
     "D8ReasonForDivorceSeperationInFuture" : null,
     "D8ReasonForDivorceDesertionInFuture" : null,
@@ -172,7 +130,7 @@
     "D8ReasonForDivorceSeperationDay" : null,
     "D8ReasonForDivorceSeperationMonth" : null,
     "D8ReasonForDivorceSeperationYear" : null,
-    "D8DerivedReasonForDivorceAdultery3dPtyNm" : "Jennifer Lawrence",
+    "D8DerivedReasonForDivorceAdultery3dPtyNm" : null,
     "D8DerivedRespondentSolicitorAddr" : null,
     "D8DerivedLivingArrangementsLastLivedAddr" : null,
     "D8Connections" : {
@@ -184,7 +142,19 @@
         "F" : null,
         "G" : null
     },
-    "D8DocumentsGenerated" : null,
+    "D8DocumentsGenerated" : [{
+        "id" : null,
+        "value" : {
+          "DocumentType": "petition",
+          "DocumentLink" : {
+            "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683"
+          },
+          "DocumentDateAdded": "2017-12-11",
+          "DocumentComment": "",
+          "DocumentFileName": "d8-eng.pdf",
+          "DocumentEmailContent": ""
+        }
+    }],
     "D8ConnectionSummary" : null,
     "D8ReasonForDivorceHasMarriage" : "YES",
     "D8ReasonForDivorceShowFiveYearsSeparatio" : "YES",
@@ -192,10 +162,16 @@
     "D8ReasonForDivorceSeperation" : null,
     "D8ReasonForDivorceSeperationBeforeMarria" : null,
     "D8ReasonForDivorceDesertion" : null,
+    "D8DerivedReasonForDivorceAdultery3rdAddr" : null,
     "D8Cohort" : "onlineSubmissionPrivateBeta",
-    "D8InferredPetitionerGender" : "female",
     "D8InferredRespondentGender" : "male",
     "D8PetitionerConsent" : "YES",
-    "PreviousReasonsForDivorce": [{"id": "1234", "value": "reason-one"}, {"id": "1122", "value": "reason-two"}],
-    "PreviousCaseId": "caseReferenceOld"
+    "RespondentContactDetailsConfidential": "share",
+    "PreviousReasonsForDivorce": [
+        {
+            "id": null,
+            "value": "adultery"
+        }
+    ],
+    "PreviousCaseId": "1234567891234567"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/amend-petition-session-submit.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/amend-petition-session-submit.json
@@ -1,0 +1,224 @@
+{
+    "cookie": {
+        "path": "/",
+        "_expires": null,
+        "originalMaxAge": null,
+        "httpOnly": true,
+        "secure": false
+    },
+    "expires": 1510922360607,
+    "screenHasMarriageBroken": "Yes",
+    "screenHasRespondentAddress": "Yes",
+    "screenHasMarriageCert": "Yes",
+    "screenHasPrinter": "Yes",
+    "helpWithFeesNeedHelp": "Yes",
+    "helpWithFeesAppliedForFees": "Yes",
+    "helpWithFeesReferenceNumber": "HWF-123-456",
+    "divorceWho": "husband",
+    "marriageDateDay": 2,
+    "marriageDateMonth": 2,
+    "marriageDateYear": 2001,
+    "marriageDate": "2001-02-02T00:00:00.000Z",
+    "marriageCanDivorce": true,
+    "marriageDateIsFuture": false,
+    "marriageDateMoreThan100": false,
+    "marriedInUk": "Yes",
+    "jurisdictionPath": [
+        "JurisdictionHabitualResidence",
+        "JurisdictionInterstitial"
+    ],
+    "jurisdictionConnection": [
+        "A",
+        "C"
+    ],
+    "connections": {
+        "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+        "C": "The Respondent is habitually resident in England and Wales"
+    },
+    "jurisdictionPetitionerResidence": "Yes",
+    "jurisdictionRespondentResidence": "Yes",
+    "jurisdictionConfidentLegal": "Yes",
+    "jurisdictionConnectionFirst": "A",
+    "petitionerContactDetailsConfidential": "share",
+    "petitionerFirstName": "John",
+    "petitionerLastName": "Smith",
+    "respondentFirstName": "Jane",
+    "respondentLastName": "Jamed",
+    "marriagePetitionerName": "John Doe",
+    "marriageRespondentName": "Jenny Benny",
+    "petitionerNameDifferentToMarriageCertificate": "Yes",
+    "petitionerNameChangedHow": [
+        "marriageCertificate"
+    ],
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
+    "petitionerPhoneNumber": "01234567890",
+    "petitionerHomeAddress": {
+        "addressType": "postcode",
+        "postcode": "SW9 9PE",
+        "address": [
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed": "true",
+        "validPostcode": true,
+        "postcodeError": "false",
+        "url": "/petitioner-respondent/address",
+        "formattedAddress": {
+            "whereabouts": [
+                null
+            ],
+            "postcode": "SW9 9PE"
+        }
+    },
+    "petitionerCorrespondenceUseHomeAddress": "Yes",
+    "petitionerCorrespondenceAddress": {
+        "addressType": "postcode",
+        "postcode": "SW9 9PE",
+        "address": [
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed": "true",
+        "validPostcode": true,
+        "postcodeError": "false",
+        "url": "/petitioner-respondent/address",
+        "formattedAddress": {
+            "whereabouts": [
+                null
+            ],
+            "postcode": "SW9 9PE"
+        }
+    },
+    "livingArrangementsLiveTogether": "Yes",
+    "respondentHomeAddress": {
+        "addressType": "postcode",
+        "postcode": "SW9 9PE",
+        "address": [
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed": "true",
+        "validPostcode": true,
+        "postcodeError": "false",
+        "url": "/petitioner-respondent/address",
+        "formattedAddress": {
+            "whereabouts": [
+                null
+            ],
+            "postcode": "SW9 9PE"
+        }
+    },
+    "respondentCorrespondenceUseHomeAddress": "No",
+    "respondentCorrespondenceAddress": {
+        "addressType": "postcode",
+        "postcode": "SW9 9PE",
+        "address": [
+            "82 Landor Road",
+            "London",
+            "SW9 9PE"
+        ],
+        "addressConfirmed": "true",
+        "validPostcode": true,
+        "postcodeError": "false",
+        "url": "/petitioner-respondent/respondent-correspondence-address",
+        "formattedAddress": {
+            "whereabouts": [
+                null
+            ],
+            "postcode": "SW9 9PE"
+        }
+    },
+    "reasonForDivorce": "unreasonable-behaviour",
+    "reasonForDivorceHasMarriageDate": true,
+    "reasonForDivorceShowAdultery": true,
+    "reasonForDivorceShowUnreasonableBehaviour": true,
+    "reasonForDivorceShowTwoYearsSeparation": true,
+    "reasonForDivorceShowFiveYearsSeparation": true,
+    "reasonForDivorceShowDesertion": true,
+    "reasonForDivorceLimitReasons": false,
+    "reasonForDivorceEnableAdultery": true,
+    "reasonForDivorceBehaviourDetails": [
+        "My wife is having an affair this week."
+    ],
+    "legalProceedings": "Yes",
+    "legalProceedingsRelated": [
+        "children"
+    ],
+    "legalProceedingsDetails": "The legal proceeding details",
+    "financialOrder": "Yes",
+    "financialOrderFor": [
+        "petitioner",
+        "children"
+    ],
+    "claimsCosts": "Yes",
+    "reasonForDivorceAdulteryIsNamed": "No",
+    "claimsCostsFrom": [
+        "respondent"
+    ],
+    "claimsCostsAppliedForFees": true,
+    "reasonForDivorceClaiming5YearSeparation": false,
+    "reasonForDivorceClaimingAdultery": false,
+    "court": {
+        "eastMidlands": {
+            "phone": "0115 955 8266",
+            "divorceCentre": "East Midlands Regional Divorce Centre",
+            "courtCity": "Nottingham",
+            "poBox": "PO Box 10447",
+            "postCode": "NG2 9QN",
+            "openingHours": "Telephone Enquiries from: 8am to 4pm",
+            "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber": "0115 955 8186",
+            "siteId": "AA01"
+        },
+        "westMidlands": {
+            "divorceCentre": "West Midlands Regional Divorce Centre",
+            "courtCity": "Stoke-on-Trent",
+            "poBox": "PO Box 3650",
+            "postCode": "ST4 9NH",
+            "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+            "email": "westmidlandsdivorce@hmcts.gsi.gov.uk",
+            "phoneNumber": "0300 123 5577",
+            "siteId": "AA02"
+        },
+        "southWest": {
+            "divorceCentre": "South West Regional Divorce Centre",
+            "courtCity": "Southampton",
+            "poBox": "PO Box 1792",
+            "postCode": "SO15 9GG",
+            "openingHours": "Telephone Enquiries from: 8am to 4pm",
+            "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+            "phoneNumber": "023 8038 4200",
+            "siteId": "AA03"
+        },
+        "northWest": {
+            "divorceCentre": "North West Regional Divorce Centre",
+            "divorceCentreAddressName": "Liverpool Civil & Family Court",
+            "courtCity": "Liverpool",
+            "street": "35 Vernon Street",
+            "postCode": "L2 2BX",
+            "openingHours": "Telephone Enquiries from: 10am to 4pm",
+            "email": "family@liverpool.countycourt.gsi.gov.uk",
+            "phoneNumber": "0300 303 0642",
+            "siteId": "AA04"
+        }
+    },
+    "courts": "eastMidlands",
+    "confirmPrayer": "Yes",
+    "d8": [{
+        "createdBy" : 12661,
+        "createdOn" : "2017-12-11",
+        "lastModifiedBy" : 12661,
+        "modifiedOn" : "2017-12-11",
+        "fileName" : "d8-eng.pdf",
+        "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861683",
+        "mimeType" : "application/pdf",
+        "status" : "OK"
+    }],
+    "petitionerConsent" : "Yes",
+    "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695",
+    "previousReasonsForDivorce": ["adultery"],
+    "previousCaseId": "1234567891234567"
+}


### PR DESCRIPTION
Ensure CCD Collections type is mapped correctly from divorce session, for PreviousReasonsForDivorceField. 

In fixing DIV-4280 the mapper allows for "NEVER" as a value alongside "YES" and "NO"

Fixes # DIV-4275 & DIV-4280

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit, ITest

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
