### PR TITLE
Revert "DIV-4267 Add respDefendsDivorce"

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -2,7 +2,6 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
-    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -274,7 +274,6 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
-    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
@@ -23,9 +23,6 @@ public class AosCaseData extends DnCaseData {
     @JsonProperty("RespWillDefendDivorce")
     private String respWillDefendDivorce;
 
-    @JsonProperty("RespDefendsDivorce")
-    private String respDefendsDivorce;
-
     @JsonProperty("RespJurisdictionDisagreeReason")
     private String respJurisdictionDisagreeReason;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -370,9 +370,6 @@ public class DivorceSession {
     private String respAdmitOrConsentToFact;
     @ApiModelProperty(value = "Will respondent defend the divorce?", allowableValues = "Yes, No, NoNoAdmission")
     private String respWillDefendDivorce;
-    @ApiModelProperty(value = "Will respondent defend the divorce - separation 2 years journey?",
-        allowableValues = "Yes, No")
-    private String respDefendsDivorce;
     @ApiModelProperty(value = "Reason respondent disagreed to claimed jurisdiction")
     private String respJurisdictionDisagreeReason;
     @ApiModelProperty(value = "Respondent country of residence")

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
@@ -205,7 +205,6 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
-    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
@@ -273,7 +273,6 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
-    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -2,7 +2,6 @@
     "RespConfirmReadPetition" : "YES",
     "RespAdmitOrConsentToFact" : "YES",
     "RespWillDefendDivorce" : "YES",
-    "RespDefendsDivorce" : "YES",
     "RespJurisdictionAgree" : "NO",
     "RespJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "RespJurisdictionRespCountryOfResidence" : "UK",

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -274,7 +274,6 @@
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
     "respWillDefendDivorce" : "YES",
-    "respDefendsDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",


### PR DESCRIPTION
Reverts hmcts/div-case-data-formatter#95

RespDefendsDivorce is an old field. This mapping is not required, as RespWillDefendDivorce, the replacing field is already mapped.

The fix this PR was meant to apply will be done on the frontend instead:
https://github.com/hmcts/div-respondent-frontend/pull/231