### PR TITLE
DIV-4329: Map previous link from textField to new CCD CaseLink type object

### DIFF
--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -209,5 +209,5 @@
     "IssueDate": "2006-02-02",
     "dueDate":"2006-02-10",
     "PreviousReasonsForDivorce": ["reason-one","reason-two"],
-    "PreviousCaseId": "caseReferenceOld"
+    "PreviousCaseId": "1234567891234567"
   }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -209,5 +209,5 @@
     "IssueDate": "2006-02-02",
     "dueDate":"2006-02-10",
     "PreviousReasonsForDivorce": ["reason-one","reason-two"],
-    "PreviousCaseId": "1234567891234567"
+    "PreviousCaseId": {"CaseReference": "1234567891234567"}
   }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
@@ -289,5 +289,5 @@
     "issueDate": "2006-02-02T00:00:00.000+0000",
     "dueDate": "2006-02-10T00:00:00.000+0000",
     "previousReasonsForDivorce": ["reason-one", "reason-two"],
-    "previousCaseId": "caseReferenceOld"
+    "previousCaseId": "1234567891234567"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -142,5 +142,5 @@
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
     "PreviousReasonsForDivorce": ["reason-one", "reason-two"],
-    "PreviousCaseId": "1234567891234567"
+    "PreviousCaseId": {"CaseReference": "1234567891234567"}
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/d8document.json
@@ -142,5 +142,5 @@
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
     "PreviousReasonsForDivorce": ["reason-one", "reason-two"],
-    "PreviousCaseId": "caseReferenceOld"
+    "PreviousCaseId": "1234567891234567"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/d8-document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/d8-document.json
@@ -232,5 +232,5 @@
     "petitionerConsent" : "Yes",
     "sessionKey": "3ef126f177936ef4537b104b950f7342a098ae3047f9ee099c8a0dbf3a63b488:e2e2ad2acf3c03722df82477f9a29a2f:23b082fff0278efe6df50277f08684c77088678ec69238dde867923aef64e46d40d7cee00ea7253942e2bc93229f60b1ff3cee1d50d561b904dcea4bfaeda695",
     "previousReasonsForDivorce": ["reason-one", "reason-two"],
-    "previousCaseId": "caseReferenceOld"
+    "previousCaseId": "1234567891234567"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CaseLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CaseLink.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class CaseLink {
+
+    @JsonProperty(value = "CaseReference")
+    private String caseReference;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -541,7 +541,7 @@ public class CoreCaseData extends AosCaseData {
     private String desertionLivedTogetherMoreTimeThanPermitted;
 
     @JsonProperty("PreviousCaseId")
-    private String previousCaseId;
+    private CaseLink previousCaseId;
 
     @JsonProperty("PreviousReasonsForDivorce")
     private List<String> previousReasonsForDivorce;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CaseLink;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.Payment;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.payment.PaymentCollection;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.corespondent.CoRespondentAnswers;
@@ -452,6 +453,7 @@ public class DivorceSession {
     @ApiModelProperty(value = "Agree to apply for Dn?", allowableValues = "Yes, No")
     private String uploadAnyOtherDocuments;
     //DnCase Fields Mapping End
+
     @ApiModelProperty(value = "Case ID from previously amended case")
     private String previousCaseId;
     @ApiModelProperty(value = "List of previous reasons used for divorce, before amending petition")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CaseLink;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.Address;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.AddressType;
@@ -25,6 +26,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.toYesNoNeverPascalCase;
@@ -130,8 +132,8 @@ public abstract class CCDCaseToDivorceMapper {
     @Mapping(source = "dueDateCoResp", target = "coRespondentAnswers.aos.dueDate",
         dateFormat = SIMPLE_DATE_FORMAT)
     @Mapping(source = "coRespLetterHolderId", target = "coRespondentAnswers.aos.letterHolderId")
-    @Mapping(source = "previousCaseId", target = "previousCaseId")
     @Mapping(source = "previousReasonsForDivorce", target = "previousReasonsForDivorce")
+    @Mapping(ignore = true, target = "previousCaseId")
     public abstract DivorceSession courtCaseDataToDivorceCaseData(CoreCaseData coreCaseData);
 
     private String translateToBooleanString(final String value) {
@@ -905,5 +907,21 @@ public abstract class CCDCaseToDivorceMapper {
         divorceSession.setReasonForDivorceAdulterySecondHandInfo(
             toYesNoPascalCase(caseData.getD8ReasonForDivorceAdulteryAnyInfo2ndHand())
         );
+    }
+
+    @AfterMapping
+    protected void mapPreviousCaseId(CoreCaseData caseData, @MappingTarget DivorceSession divorceSession) {
+
+        String caseLink = translateCaseLinkToString(caseData.getPreviousCaseId());
+        divorceSession.setPreviousCaseId(caseLink);
+    }
+
+    private String translateCaseLinkToString(final CaseLink caseLink) {
+        // translate from CaseLink type to String
+        if (Objects.isNull(caseLink)) {
+            return null;
+        }
+
+        return caseLink.getCaseReference();
     }
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/amend-petition-case.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/amend-petition-case.json
@@ -197,5 +197,5 @@
     "D8InferredRespondentGender" : "male",
     "D8PetitionerConsent" : "YES",
     "PreviousReasonsForDivorce": ["reason-one","reason-two"],
-    "PreviousCaseId": "caseReferenceOld"
+    "PreviousCaseId": {"CaseReference": "1234567891234567"}
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/amend-petition-divorce.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/amend-petition-divorce.json
@@ -237,5 +237,5 @@
     "reasonForDivorceAdulteryWhereDetails":"On a washing machine.",
     "petitionerConsent" : "Yes",
     "previousReasonsForDivorce": ["reason-one", "reason-two"],
-    "previousCaseId": "caseReferenceOld"
+    "previousCaseId": "1234567891234567"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
@@ -172,5 +172,5 @@
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
     "PreviousReasonsForDivorce": ["adultery"],
-    "PreviousCaseId": "1234567891234567"
+    "PreviousCaseId": {"CaseReference": "1234567891234567"}
 }


### PR DESCRIPTION
DIV-4329 Map previous link from TextField to CCD CaseTypeLink type.

Changed the mapping in the CFS so that it:
- can consume CCD previousCaseId as text from Divorce Session Data and transform this into a new CaseLink type within the CCD data. 
- Transform data in this new CaseLink type from CCD data to a text field in the Divorce Session data. 

See below for more information on this new CaseLink type created by CCD
https://github.com/hmcts/ccd-data-store-api/blob/master/docs/api/case-data.md#caselink

## Type of change

- [x] New feature (non-breaking change which adds functionality)