### PR TITLE
DIV-4574 - ignore previousIssueDate when going from Divorce -> CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -120,7 +120,7 @@ public abstract class DivorceCaseToCCDMapper {
     @Mapping(source = "reasonForDivorceLivingApartDate", dateFormat = SIMPLE_DATE_FORMAT,
         target = "reasonForDivorceLivingApartDate")
     @Mapping(ignore = true, target = "previousCaseId")
-    @Mapping(source = "previousIssueDate", dateFormat = SIMPLE_DATE_FORMAT, target = "previousIssueDate")
+    @Mapping(ignore = true, dateFormat = SIMPLE_DATE_FORMAT, target = "previousIssueDate")
     @Mapping(source = "previousReasonsForDivorce", target = "previousReasonsForDivorce")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/amend-petition-ccd-submitted.json
@@ -172,6 +172,5 @@
     "D8PetitionerConsent" : "YES",
     "RespondentContactDetailsConfidential": "share",
     "PreviousCaseId": {"CaseReference": "1234567891234567"},
-    "PreviousIssueDate": "2006-03-03",
     "PreviousReasonsForDivorce": ["adultery"]
 }


### PR DESCRIPTION
# Description

Because it's generated by CCD and it's read-only for citizens

Fixes #DIV-4574

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
