### PR TITLE
Add Respondent Solicitor Email and Phone contact fields

### DIFF
--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -52,6 +52,8 @@
     "D8DerivedRespondentCorrespondenceAddr" : "82 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentSolicitorName" : "Justin",
     "D8RespondentSolicitorCompany" : "Case",
+    "D8RespondentSolicitorEmail" : "justin@example.com",
+    "D8RespondentSolicitorPhone" : "01234567890",
     "D8RespondentCorrespondenceSendToSol" : null,
     "D8RespondentSolicitorAddress" : {
         "AddressLine1":null,

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
@@ -227,6 +227,8 @@
     "courts": "eastMidlands",
     "respondentSolicitorName": "Justin",
     "respondentSolicitorCompany": "Case",
+    "respondentSolicitorEmail" : "justin@example.com",
+    "respondentSolicitorPhoneNumber" : "01234567890",
     "respondentSolicitorAddress": {
         "addressType": "postcode",
         "postcode": "SW9 9PE",

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -47,6 +47,8 @@
     "D8DerivedRespondentCurrentName": "Jane Jamed",
     "D8RespondentSolicitorName": "Justin",
     "D8RespondentSolicitorCompany": "Case",
+    "D8RespondentSolicitorEmail" : "justin@example.com",
+    "D8RespondentSolicitorPhone" : "01234567890",
     "D8DerivedRespondentSolicitorDetails": "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress": {
         "AddressLine1": null,

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
@@ -258,6 +258,8 @@
   },
   "respondentSolicitorName": "Justin",
   "respondentSolicitorCompany": "Case",
+  "respondentSolicitorEmail" : "justin@example.com",
+  "respondentSolicitorPhoneNumber" : "01234567890",
   "respondentSolicitorAddress": {
     "addressType": "postcode",
     "postcode": "A AAA",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -549,4 +549,9 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("PreviousReasonsForDivorce")
     private List<String> previousReasonsForDivorce;
 
+    @JsonProperty("D8RespondentSolicitorEmail")
+    private String d8RespondentSolicitorEmail;
+
+    @JsonProperty("D8RespondentSolicitorPhone")
+    private String d8RespondentSolicitorPhone;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -294,6 +294,10 @@ public class DivorceSession {
     private String respondentSolicitorName;
     @ApiModelProperty(value = "Company of solicitor used by respondent.")
     private String respondentSolicitorCompany;
+    @ApiModelProperty(value = "Email of solicitor used by respondent.")
+    private String respondentSolicitorEmail;
+    @ApiModelProperty(value = "Phone number of solicitor used by respondent.")
+    private String respondentSolicitorPhoneNumber;
     @ApiModelProperty(value = "Address of solicitor used by respondent.")
     private Address respondentSolicitorAddress;
     @ApiModelProperty(value = "Agree to statement of truth?", allowableValues = "Yes, No")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -105,6 +105,8 @@ public abstract class CCDCaseToDivorceMapper {
     @Mapping(source = "d8Documents", target = "d8Documents")
     @Mapping(source = "d8RespondentSolicitorName", target = "respondentSolicitorName")
     @Mapping(source = "d8RespondentSolicitorCompany", target = "respondentSolicitorCompany")
+    @Mapping(source = "d8RespondentSolicitorEmail", target = "respondentSolicitorEmail")
+    @Mapping(source = "d8RespondentSolicitorPhone", target = "respondentSolicitorPhoneNumber")
     @Mapping(source = "d8RespondentSolicitorAddress.postCode", target = "respondentSolicitorAddress.postcode")
     @Mapping(source = "createdDate", dateFormat = SIMPLE_DATE_FORMAT, target = "createdDate")
     @Mapping(source = "issueDate", dateFormat = SIMPLE_DATE_FORMAT, target = "issueDate")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToCCDMapper.java
@@ -116,6 +116,8 @@ public abstract class DivorceCaseToCCDMapper {
     @Mapping(source = "d8Documents", target = "d8Documents")
     @Mapping(source = "respondentSolicitorName", target = "d8RespondentSolicitorName")
     @Mapping(source = "respondentSolicitorCompany", target = "d8RespondentSolicitorCompany")
+    @Mapping(source = "respondentSolicitorEmail", target = "d8RespondentSolicitorEmail")
+    @Mapping(source = "respondentSolicitorPhoneNumber", target = "d8RespondentSolicitorPhone")
     @Mapping(source = "reasonForDivorceDecisionDate", dateFormat = SIMPLE_DATE_FORMAT,
         target = "reasonForDivorceDecisionDate")
     @Mapping(source = "reasonForDivorceLivingApartDate", dateFormat = SIMPLE_DATE_FORMAT,

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/addresscase.json
@@ -52,6 +52,8 @@
     "D8DerivedRespondentCorrespondenceAddr" : "82 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentSolicitorName" : "Justin",
     "D8RespondentSolicitorCompany" : "Case",
+    "D8RespondentSolicitorEmail" : "justin@example.com",
+    "D8RespondentSolicitorPhone" : "01234567890",
     "D8RespondentCorrespondenceSendToSol" : null,
     "D8RespondentSolicitorAddress" : {
         "AddressLine1":null,

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
@@ -252,6 +252,8 @@
     },
     "respondentSolicitorName":"Justin",
     "respondentSolicitorCompany":"Case",
+    "respondentSolicitorEmail" : "justin@example.com",
+    "respondentSolicitorPhoneNumber" : "01234567890",
     "respondentSolicitorAddress":{
         "addressType":"postcode",
         "postcode":"SW9 9PE",

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/addresscase.json
@@ -56,6 +56,8 @@
     "D8DerivedRespondentCorrespondenceAddr" : "82 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentSolicitorName" : "Justin",
     "D8RespondentSolicitorCompany" : "Case",
+    "D8RespondentSolicitorEmail" : "justin@example.com",
+    "D8RespondentSolicitorPhone" : "01234567890",
     "D8RespondentCorrespondenceSendToSol" : null,
     "D8RespondentSolicitorAddress" : null,
     "D8RespondentCorrespondenceUseHomeAddress" : "Solicitor",

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
@@ -247,6 +247,8 @@
   },
   "respondentSolicitorName": "Justin",
   "respondentSolicitorCompany": "Case",
+  "respondentSolicitorEmail" : "justin@example.com",
+  "respondentSolicitorPhoneNumber" : "01234567890",
   "respondentSolicitorAddress": {
     "addressType": "postcode",
     "postcode": "A AAA",


### PR DESCRIPTION
# Description

Note: Only merge after fields have been verified to be merged in CCD.
- Verified in Prod. Merge this in and then merge
https://github.com/hmcts/div-petitioner-frontend/pull/523

Adds the required Respondent Solicitor Email and Phone fields to be mapped.

[DIV-4726](https://tools.hmcts.net/jira/browse/DIV-4726)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests ran.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
