### PR TITLE
DIV-4832 - don't throw NPE if document link is missing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -24,9 +24,12 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.strategy.reasonfordivorc
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.toYesNoNeverPascalCase;
@@ -292,6 +295,17 @@ public abstract class CCDCaseToDivorceMapper {
                                                             @MappingTarget DivorceSession divorceSession) {
         divorceSession.setRespondentNameAsOnMarriageCertificate(
                 toYesNoPascalCase(caseData.getD8RespondentNameAsOnMarriageCertificate()));
+    }
+
+    @AfterMapping
+    protected void mapMarriageCertificateFiles(CoreCaseData caseData,
+                                                            @MappingTarget DivorceSession divorceSession) {
+        Optional.ofNullable(divorceSession.getMarriageCertificateFiles())
+            .ifPresent(uploadedFiles -> {
+                divorceSession.setMarriageCertificateFiles(uploadedFiles.stream()
+                    .filter(uploadedFile -> uploadedFile.getId() != null)
+                    .collect(Collectors.toCollection(ArrayList::new)));
+            });
     }
 
     @AfterMapping

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
@@ -8,7 +8,10 @@ import org.mapstruct.ReportingPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DocumentLink;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.UploadedFile;
+
+import java.util.Optional;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 
@@ -28,7 +31,11 @@ public abstract class DocumentCollectionDivorceFormatMapper {
     @AfterMapping
     protected void mapDocumentIDToDocumentObject(CollectionMember<Document> document,
                                                  @MappingTarget  UploadedFile result ) {
-        documentUrlRewrite.getDocumentId(document.getValue().getDocumentLink().getDocumentUrl())
-            .ifPresent(result::setId);
+
+        Optional.of(document)
+            .map(documentCollectionMember -> document.getValue())
+            .map(Document::getDocumentLink)
+            .map(DocumentLink::getDocumentUrl)
+            .ifPresent(s -> documentUrlRewrite.getDocumentId(s).ifPresent(result::setId));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
@@ -16,6 +16,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -61,5 +62,16 @@ public class DocumentCollectionDivorceFormatMapperUTest {
     @Test
     public void shouldReturnNullWithNullInput() {
         assertNull(mapper.map(null));
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForNullDocumentLink() {
+        final Document document = new Document();
+
+        final CollectionMember<Document> collectionMember = new CollectionMember<>();
+        collectionMember.setValue(document);
+
+        assertThatCode(() -> mapper.map(collectionMember))
+            .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentsMappingUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentsMappingUTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ccdtodivorceformat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceApplication;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.UploadedFile;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.CCDCaseToDivorceMapper;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = CaseFormatterServiceApplication.class)
+public class DocumentsMappingUTest {
+
+    @Autowired
+    private CCDCaseToDivorceMapper mapper;
+
+    @Test
+    public void shouldHandleDocumentLinkBeingNull()
+        throws URISyntaxException, IOException {
+
+        CoreCaseData coreCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/ccdtodivorcemapping/ccd/document-link-null.json", CoreCaseData.class);
+
+        DivorceSession actualDivorceSession = mapper.courtCaseDataToDivorceCaseData(coreCaseData);
+
+        List<UploadedFile> marriageCertificateFiles = actualDivorceSession.getMarriageCertificateFiles();
+        assertEquals(marriageCertificateFiles.size(), 1);
+        assertEquals(marriageCertificateFiles.get(0).getFileName(), "some-file.pdf");
+    }
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/document-link-null.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/document-link-null.json
@@ -1,0 +1,29 @@
+{
+    "D8DocumentsUploaded" : [
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentLink" : {
+                    "document_url" : "https://api-gateway.test.dm.reform.hmcts.net/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+                    "document_binary_url" : null,
+                    "document_filename" : "some-file.pdf"
+                },
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "some-file.pdf",
+                "DocumentEmailContent" : ""
+            }
+        },
+        {
+            "id" : null,
+            "value" : {
+                "DocumentType" : "other",
+                "DocumentDateAdded" : "2017-12-11",
+                "DocumentComment" : "",
+                "DocumentFileName" : "broken.png",
+                "DocumentEmailContent" : ""
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Description

ServiceNow number: INC0456401

When mapping the uploaded documents array JSON, a document somehow didn't have a document link

Usuaully it's
```
      {
        "id": "1234",
        "value": {
          "DocumentLink": {
            "document_url": "url",
            "document_filename": "file.pdf",
            "document_binary_url": "url"
          },
          "DocumentType": "test",
          "DocumentComment": null,
          "DocumentFileName": null,
          "DocumentDateAdded": null,
          "DocumentEmailContent": null
        }
      },
```
But we see
```
      {
        "id": "1234",
        "value": {
          "DocumentType": null,
          "DocumentComment": null,
          "DocumentFileName": null,
          "DocumentDateAdded": null,
          "DocumentEmailContent": null
        }
      },
```
Fixes #DIV-4832

## Type of change

Please delete options that are not relevant.

- [x Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
