### PR TITLE
DIV-4860 - update the divorcecase contact email to contactdivorce@...

### DIFF
--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
@@ -198,7 +198,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
@@ -219,7 +219,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/how-name-changed.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/how-name-changed.json
@@ -206,7 +206,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-6-12.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-6-12.json
@@ -203,7 +203,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-all.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-all.json
@@ -204,7 +204,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
@@ -198,7 +198,7 @@
           "poBox": "PO Box 10447",
           "postCode": "NG2 9QN",
           "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-          "email": "divorcecase@justice.gov.uk",
+          "email": "contactdivorce@justice.gov.uk",
           "phoneNumber": "0300 303 0642",
           "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-adultery.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-adultery.json
@@ -222,7 +222,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-desertion.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-desertion.json
@@ -197,7 +197,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-separation.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-separation.json
@@ -201,7 +201,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-unreasonable-behaviour.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/reason-unreasonable-behaviour.json
@@ -197,7 +197,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/same-sex.json
+++ b/src/integrationTest/resources/fixtures/ccdtodivorcemapping/divorce/same-sex.json
@@ -199,7 +199,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/additional-payment.json
@@ -212,7 +212,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/addresses.json
@@ -151,7 +151,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/d8-document.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/d8-document.json
@@ -213,7 +213,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/dn.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/dn.json
@@ -149,7 +149,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/how-name-changed.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/how-name-changed.json
@@ -216,7 +216,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/jurisdiction-6-12.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/jurisdiction-6-12.json
@@ -214,7 +214,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/jurisdiction-all.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/jurisdiction-all.json
@@ -213,7 +213,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/overwrite-payment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/overwrite-payment.json
@@ -212,7 +212,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment-id-only.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment-id-only.json
@@ -212,7 +212,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/payment.json
@@ -212,7 +212,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-adultery.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-adultery.json
@@ -223,7 +223,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-desertion.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-desertion.json
@@ -212,7 +212,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-separation.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-separation.json
@@ -212,7 +212,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-unreasonable-behaviour.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/reason-unreasonable-behaviour.json
@@ -225,7 +225,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/same-sex.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/same-sex.json
@@ -209,7 +209,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ court:
                 \"poBox\": \"PO Box 10447\",
                 \"postCode\": \"NG2 9QN\",
                 \"openingHours\": \"Telephone Enquiries from: 8.30am to 5pm\",
-                \"email\": \"divorcecase@justice.gov.uk\",
+                \"email\": \"contactdivorce@justice.gov.uk\",
                 \"phoneNumber\": \"0300 303 0642\",
                 \"siteId\": \"AA07\"
               }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/additional-payment.json
@@ -195,7 +195,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-abroad.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-abroad.json
@@ -283,7 +283,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-derived-not-null.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-derived-not-null.json
@@ -291,7 +291,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-null.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses-null.json
@@ -186,7 +186,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/addresses.json
@@ -150,7 +150,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/amend-petition-divorce.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/amend-petition-divorce.json
@@ -212,7 +212,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
@@ -150,7 +150,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/help-fees-null.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/help-fees-null.json
@@ -195,7 +195,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/how-name-changed.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/how-name-changed.json
@@ -206,7 +206,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-6-12.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-6-12.json
@@ -200,7 +200,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-all.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/jurisdiction-all.json
@@ -200,7 +200,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/marriage-date-null.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/marriage-date-null.json
@@ -272,7 +272,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/payment.json
@@ -213,7 +213,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-adultery.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-adultery.json
@@ -213,7 +213,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-desertion.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-desertion.json
@@ -202,7 +202,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-separation.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-separation.json
@@ -202,7 +202,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-unreasonable-behaviour.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/reason-unreasonable-behaviour.json
@@ -213,7 +213,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/same-sex.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/same-sex.json
@@ -204,7 +204,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA01"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-behaviour.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-behaviour.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA01"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-desertion.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-desertion.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA01"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-null.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-null.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA01"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-separation.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-separation.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA01"
         }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn.json
@@ -148,7 +148,7 @@
             "poBox": "PO Box 10447",
             "postCode": "NG2 9QN",
             "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-            "email": "divorcecase@justice.gov.uk",
+            "email": "contactdivorce@justice.gov.uk",
             "phoneNumber": "0300 303 0642",
             "siteId": "AA07"
         }


### PR DESCRIPTION
# Description

Now that all Divorce cases are being routed to the CTSC, the contact email address displayed in all notification email sent to citizens should be standardised.

Fixes #DIV-4860 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
