### PR TITLE
DIV-4929 Apply fix for document mapping and checking if date is empty string

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
@@ -7,7 +7,6 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DocumentLink;
@@ -15,7 +14,6 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
@@ -6,8 +6,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
-import org.mapstruct.ap.shaded.freemarker.template.SimpleDate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DocumentLink;
@@ -15,11 +15,9 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
-import java.util.zip.DataFormatException;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 
@@ -58,6 +56,7 @@ public abstract class DocumentCollectionDivorceFormatMapper {
             }
         } catch (ParseException ex) {
             log.warn("Unable to parse a date string on document");
+            throw new RuntimeException("Parse date on documents error", ex);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DocumentCollectionDivorceFormatMapper.java
@@ -1,20 +1,29 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.mapper;
 
+import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
+import org.mapstruct.ap.shaded.freemarker.template.SimpleDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DocumentLink;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.UploadedFile;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.Optional;
+import java.util.zip.DataFormatException;
 
 import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 
+@Slf4j
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 @SuppressWarnings("squid:S1610")
 public abstract class DocumentCollectionDivorceFormatMapper {
@@ -23,19 +32,32 @@ public abstract class DocumentCollectionDivorceFormatMapper {
     private DocumentUrlRewrite documentUrlRewrite;
 
     @Mapping(source = "value.documentLink.documentFilename", target = "fileName")
-    @Mapping(source = "value.documentDateAdded", dateFormat = SIMPLE_DATE_FORMAT, target = "createdOn")
     @Mapping(source = "value.documentLink.documentUrl", target = "fileUrl")
     public abstract UploadedFile map(CollectionMember<Document> documentCollectionMember);
 
 
     @AfterMapping
     protected void mapDocumentIDToDocumentObject(CollectionMember<Document> document,
-                                                 @MappingTarget  UploadedFile result ) {
+                                                 @MappingTarget  UploadedFile result) {
 
         Optional.of(document)
             .map(documentEntry -> document.getValue())
             .map(Document::getDocumentLink)
             .map(DocumentLink::getDocumentUrl)
             .ifPresent(url -> documentUrlRewrite.getDocumentId(url).ifPresent(result::setId));
+    }
+
+    @AfterMapping
+    protected void mapCreatedDateCheckEmpty(CollectionMember<Document> document,
+                                            @MappingTarget  UploadedFile result) {
+        try {
+            if (document.getValue().getDocumentDateAdded() != null && !document.getValue().getDocumentDateAdded().isEmpty()) {
+                SimpleDateFormat dateFormat = new SimpleDateFormat(SIMPLE_DATE_FORMAT);
+                Date date = new Date(dateFormat.parse(document.getValue().getDocumentDateAdded()).getTime());
+                result.setCreatedOn(date);
+            }
+        } catch (ParseException ex) {
+            log.warn("Unable to parse a date string on document");
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
@@ -31,9 +31,8 @@ public class DocumentCollectionDivorceFormatMapperUTest {
     private DocumentCollectionDivorceFormatMapper mapper;
 
     @Test
-    public void shouldMapUploadedFileToCollectionMember() throws ParseException {
+    public void shouldMapUploadedFileToCollectionMember() {
         final String dateDocumentAdded = "2012-11-11";
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 
         final Document document = new Document();
         final DocumentLink documentLink = new DocumentLink();
@@ -57,11 +56,11 @@ public class DocumentCollectionDivorceFormatMapperUTest {
         assertEquals(0, uploadedFile.getLastModifiedBy());
         assertEquals(FILE_NAME, uploadedFile.getFileName());
         assertEquals(FILE_URL, uploadedFile.getFileUrl());
-        assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
+        assertNull(uploadedFile.getCreatedOn());
     }
 
     @Test
-    public void shouldMapDatesCorrectly() throws ParseException {
+    public void shouldMapDateCorrectly() throws ParseException {
         final String dateDocumentAdded = "2012-11-11";
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 
@@ -78,14 +77,6 @@ public class DocumentCollectionDivorceFormatMapperUTest {
 
         final UploadedFile uploadedFile = mapper.map(collectionMember);
 
-        assertNull(uploadedFile.getStatus());
-        assertNull(uploadedFile.getMimeType());
-        assertNull(uploadedFile.getModifiedOn());
-        assertNull(uploadedFile.getFileType());
-        assertEquals(0, uploadedFile.getCreatedBy());
-        assertEquals(0, uploadedFile.getLastModifiedBy());
-        assertEquals(FILE_NAME, uploadedFile.getFileName());
-        assertEquals(FILE_URL, uploadedFile.getFileUrl());
         assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
@@ -57,7 +57,7 @@ public class DocumentCollectionDivorceFormatMapperUTest {
         assertEquals(0, uploadedFile.getLastModifiedBy());
         assertEquals(FILE_NAME, uploadedFile.getFileName());
         assertEquals(FILE_URL, uploadedFile.getFileUrl());
-        //assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
+        assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
@@ -80,6 +80,24 @@ public class DocumentCollectionDivorceFormatMapperUTest {
         assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
     }
 
+    @Test(expected = RuntimeException.class)
+    public void shouldThrowRuntimeExceptionOnBadDateFormat() {
+        final String dateDocumentAdded = "wrong-format-1234";
+
+        final Document document = new Document();
+        final DocumentLink documentLink = new DocumentLink();
+        documentLink.setDocumentUrl(FILE_URL);
+        documentLink.setDocumentFilename(FILE_NAME);
+        document.setDocumentLink(documentLink);
+        document.setDocumentFileName(FILE_NAME);
+        document.setDocumentDateAdded(dateDocumentAdded);
+
+        final CollectionMember<Document> collectionMember = new CollectionMember<>();
+        collectionMember.setValue(document);
+
+        mapper.map(collectionMember);
+    }
+
     @Test
     public void shouldReturnNullWithNullInput() {
         assertNull(mapper.map(null));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentCollectionDivorceFormatMapperUTest.java
@@ -42,6 +42,36 @@ public class DocumentCollectionDivorceFormatMapperUTest {
         document.setDocumentLink(documentLink);
         document.setDocumentFileName(FILE_NAME);
         document.setDocumentDateAdded(dateDocumentAdded);
+        document.setDocumentDateAdded("");
+
+        final CollectionMember<Document> collectionMember = new CollectionMember<>();
+        collectionMember.setValue(document);
+
+        final UploadedFile uploadedFile = mapper.map(collectionMember);
+
+        assertNull(uploadedFile.getStatus());
+        assertNull(uploadedFile.getMimeType());
+        assertNull(uploadedFile.getModifiedOn());
+        assertNull(uploadedFile.getFileType());
+        assertEquals(0, uploadedFile.getCreatedBy());
+        assertEquals(0, uploadedFile.getLastModifiedBy());
+        assertEquals(FILE_NAME, uploadedFile.getFileName());
+        assertEquals(FILE_URL, uploadedFile.getFileUrl());
+        //assertEquals(dateFormat.parse(dateDocumentAdded), uploadedFile.getCreatedOn());
+    }
+
+    @Test
+    public void shouldMapDatesCorrectly() throws ParseException {
+        final String dateDocumentAdded = "2012-11-11";
+        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
+
+        final Document document = new Document();
+        final DocumentLink documentLink = new DocumentLink();
+        documentLink.setDocumentUrl(FILE_URL);
+        documentLink.setDocumentFilename(FILE_NAME);
+        document.setDocumentLink(documentLink);
+        document.setDocumentFileName(FILE_NAME);
+        document.setDocumentDateAdded(dateDocumentAdded);
 
         final CollectionMember<Document> collectionMember = new CollectionMember<>();
         collectionMember.setValue(document);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentsMappingUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DocumentsMappingUTest.java
@@ -14,9 +14,13 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestU
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.MappingCommons.SIMPLE_DATE_FORMAT;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CaseFormatterServiceApplication.class)
@@ -37,5 +41,25 @@ public class DocumentsMappingUTest {
         List<UploadedFile> marriageCertificateFiles = actualDivorceSession.getMarriageCertificateFiles();
         assertEquals(marriageCertificateFiles.size(), 1);
         assertEquals(marriageCertificateFiles.get(0).getFileName(), "some-file.pdf");
+    }
+
+    @Test
+    public void shouldHandleDocumentDateBeingEmptyString()
+        throws URISyntaxException, IOException, ParseException {
+
+        CoreCaseData coreCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/ccdtodivorcemapping/ccd/document-dates-empty.json",
+                CoreCaseData.class);
+
+        DivorceSession actualDivorceSession = mapper.courtCaseDataToDivorceCaseData(coreCaseData);
+
+        List<UploadedFile> marriageCertificateFiles = actualDivorceSession.getMarriageCertificateFiles();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat(SIMPLE_DATE_FORMAT);
+        String date = dateFormat.format(marriageCertificateFiles.get(0).getCreatedOn());
+
+        assertEquals(marriageCertificateFiles.size(), 3);
+        assertEquals(marriageCertificateFiles.get(0).getFileName(), "some-file.pdf");
+        assertEquals(date, "2019-05-10");
     }
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/document-dates-empty.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/document-dates-empty.json
@@ -1,0 +1,83 @@
+{
+    "D8DocumentsGenerated": [
+        {
+            "id": "186c518a-dcd3-4ecb-8062-24a2fbe36ca2",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/8e1dbf06-6d2f-4ca7-9361-c84c02765e60",
+                    "document_filename": "d8petition1557498821211845.pdf",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/8e1dbf06-6d2f-4ca7-9361-c84c02765e60/binary"
+                },
+                "DocumentType": "petition",
+                "DocumentComment": null,
+                "DocumentFileName": "d8petition1557498821211845",
+                "DocumentDateAdded": null,
+                "DocumentEmailContent": null
+            }
+        },
+        {
+            "id": "04e78b6b-3a6f-4db7-b0c5-f8eeb814a83d",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/9dcd5318-3ae1-454f-9fbd-5afe17f30cd2",
+                    "document_filename": "aosinvitation1557498821211845.pdf",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/9dcd5318-3ae1-454f-9fbd-5afe17f30cd2/binary"
+                },
+                "DocumentType": "aos",
+                "DocumentComment": null,
+                "DocumentFileName": "aosinvitation1557498821211845",
+                "DocumentDateAdded": null,
+                "DocumentEmailContent": null
+            }
+        }
+    ],
+    "ReceivedAOSfromResp": null,
+    "D8ReasonForDivorceShowUnreasonableBehavi": "YES",
+    "D8DocumentsUploaded": [
+        {
+            "id": "891756e8-3d0d-4ffe-850d-1bb4ec5970df",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c05ea515-e67a-4820-94f5-d8fff440369d",
+                    "document_filename": "some-file.pdf",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/c05ea515-e67a-4820-94f5-d8fff440369d/binary"
+                },
+                "DocumentType": "other",
+                "DocumentComment": null,
+                "DocumentFileName": "some-file.pdf",
+                "DocumentDateAdded": "2019-05-10",
+                "DocumentEmailContent": null
+            }
+        },
+        {
+            "id": "fe22b985-d9c0-43ec-9d3e-358f7d357244",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/34a467de-9997-4215-93b8-490fcba1238e",
+                    "document_filename": "Email WU19D87604.pdf",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/34a467de-9997-4215-93b8-490fcba1238e/binary"
+                },
+                "DocumentType": "d9h",
+                "DocumentComment": null,
+                "DocumentFileName": null,
+                "DocumentDateAdded": null,
+                "DocumentEmailContent": null
+            }
+        },
+        {
+            "id": "ef165cbe-1efa-411a-9539-50523cf9d738",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/98b9eb60-e41a-41e9-81ba-b1862301d92e",
+                    "document_filename": "EMAIL TO SERVICE.pdf",
+                    "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal:443/documents/98b9eb60-e41a-41e9-81ba-b1862301d92e/binary"
+                },
+                "DocumentType": "email",
+                "DocumentComment": null,
+                "DocumentFileName": null,
+                "DocumentDateAdded": "",
+                "DocumentEmailContent": null
+            }
+        }
+    ]
+}


### PR DESCRIPTION
We have a bug in Prod where we see Parse errors when trying to parse an empty string.
See ticket for more details. 

[Prevent Parse errors when document date is empty string](https://tools.hmcts.net/jira/browse/DIV-4929)