### PR TITLE
Override Spring's management endpoint cache to 30 seconds in AAT/Preview

### DIFF
--- a/charts/div-cfs/values.aat.template.yaml
+++ b/charts/div-cfs/values.aat.template.yaml
@@ -4,7 +4,7 @@ java:
         REFORM_ENVIRONMENT: "aat"
         IDAM_API_BASEURL : "https://idam-api.aat.platform.hmcts.net"
         APPINSIGHTS_INSTRUMENTATIONKEY: "dummy"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cfs/values.aat.template.yaml
+++ b/charts/div-cfs/values.aat.template.yaml
@@ -4,6 +4,7 @@ java:
         REFORM_ENVIRONMENT: "aat"
         IDAM_API_BASEURL : "https://idam-api.aat.platform.hmcts.net"
         APPINSIGHTS_INSTRUMENTATIONKEY: "dummy"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cfs/values.preview.template.yaml
+++ b/charts/div-cfs/values.preview.template.yaml
@@ -4,7 +4,7 @@ java:
         REFORM_ENVIRONMENT: "aat"
         IDAM_API_BASEURL : "https://idam-api.aat.platform.hmcts.net"
         APPINSIGHTS_INSTRUMENTATIONKEY: "dummy"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cfs/values.preview.template.yaml
+++ b/charts/div-cfs/values.preview.template.yaml
@@ -4,6 +4,7 @@ java:
         REFORM_ENVIRONMENT: "aat"
         IDAM_API_BASEURL : "https://idam-api.aat.platform.hmcts.net"
         APPINSIGHTS_INSTRUMENTATIONKEY: "dummy"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -2,3 +2,5 @@ vault_env           = "preprod"
 idam_api_baseurl    = "https://idam-api.aat.platform.hmcts.net"
 
 capacity            = "2"
+
+health_check_ttl = 30000

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,6 +28,6 @@ module "div-cfs" {
         REFORM_ENVIRONMENT                                    = "${var.env}"
         IDAM_API_BASEURL                                      = "${var.idam_api_baseurl}"
         DOCUMENT_MANAGEMENT_STORE_URL                         = "${local.dm_store_url}"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE                = "${var.health_check_ttl}"
     }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,5 +28,6 @@ module "div-cfs" {
         REFORM_ENVIRONMENT                                    = "${var.env}"
         IDAM_API_BASEURL                                      = "${var.idam_api_baseurl}"
         DOCUMENT_MANAGEMENT_STORE_URL                         = "${local.dm_store_url}"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
     }
 }

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,2 +1,4 @@
 vault_env           = "preprod"
 idam_api_baseurl    = "https://idam-api.aat.platform.hmcts.net"
+
+health_check_ttl = 30000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -52,3 +52,8 @@ variable "vault_env" {}
 variable "common_tags" {
     type = "map"
 }
+
+variable "health_check_ttl" {
+    type = "string"
+    value = "4000"
+}


### PR DESCRIPTION
# Description

To prevent hammering AAT, as every `/health` call checks _every_ dependent service, generating sometimes ~30 subsequent calls (e.g COS)

Tested locally via
`MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE=60000 ./gradlew clean bootrun`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
