### PR TITLE
Added CCD fields that are being removed on Add Document Mapper

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -540,4 +540,21 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("PreviousReasonsForDivorce")
     private List<String> previousReasonsForDivorce;
 
+    @JsonProperty("DNApprovalDate")
+    private String dnApprovalDate;
+
+    @JsonProperty("BulkListingCaseId")
+    private String bulkListingCaseId;
+
+    @JsonProperty("CostsClaimGranted")
+    private String costsClaimGranted;
+
+    @JsonProperty("DecreeNisiGrantedDate")
+    private String decreeNisiGrantedDate;
+
+    @JsonProperty("CourtName")
+    private String courtName;
+
+    @JsonProperty("DateAndTimeOfHearing")
+    private List<CollectionMember<HearingDateTime>> dateAndTimeOfHearing;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/HearingDateTime.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/HearingDateTime.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class HearingDateTime {
+
+    @JsonProperty("DateOfHearing")
+    private String dateOfHearing;
+
+    @JsonProperty("TimeOfHearing")
+    private String timeOfHearing;
+}


### PR DESCRIPTION
# Description

When the generate-document endpoint on COS was triggered, it calls CFS to add the newly generated document to the existing, it maps the input data to the CoreCaseData model on CFS. This model is set to ignoreUnknownProperties so it drops fields that aren't defined in the model, in this case all the recently added fields for Bulk Case Listing.

This PR simply adds in the missing fields so they aren't lost at the mapping stage, whilst we probably discuss a more ideal solution.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Model change so no internal automated test. Manual test will prove this, and an upcoming COS integration test.

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
