### PR TITLE
Added unit test for Json parsing CoreCaseData from Map

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseData.java
@@ -544,7 +544,7 @@ public class CoreCaseData extends AosCaseData {
     private String dnApprovalDate;
 
     @JsonProperty("BulkListingCaseId")
-    private String bulkListingCaseId;
+    private CaseLink bulkListingCaseId;
 
     @JsonProperty("CostsClaimGranted")
     private String costsClaimGranted;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseDataJsonTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/CoreCaseDataJsonTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class CoreCaseDataJsonTest {
+
+    private static final String expectedJsonPath = "fixtures/model/ccd/CoreCaseData.json";
+    private static final String inputJsonPath = "fixtures/model/ccd/InputCoreCaseDataMap.json";
+
+    @Test
+    public void givenJsonOfCoreCaseDataModel_whenMappedToCoreCaseData_thenReturnAllModelledProperties() throws Exception {
+        Map<String, Object> expectedCoreCaseData = ObjectMapperTestUtil.retrieveFileContentsAsObject(expectedJsonPath, Map.class);
+
+        CoreCaseData coreCaseData = ObjectMapperTestUtil.retrieveFileContentsAsObject(inputJsonPath, CoreCaseData.class);
+        Map<String, Object> coreCaseDataMap = ObjectMapperTestUtil.convertJsonToObject(
+            ObjectMapperTestUtil.convertObjectToJson(coreCaseData), Map.class
+        );
+
+        assertEquals(expectedCoreCaseData, coreCaseDataMap);
+    }
+}

--- a/src/test/resources/fixtures/model/ccd/CoreCaseData.json
+++ b/src/test/resources/fixtures/model/ccd/CoreCaseData.json
@@ -1,0 +1,165 @@
+{
+    "D8DerivedRespondentHomeAddress": "88 Landor Road\nLondon\nSW9 9PE",
+    "D8RespondentHomeAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SS SSS",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "D8ScreenHasMarriageCert": "YES",
+    "DocumentsUploadedDN": [],
+    "D8DivorceClaimFrom": [
+        "respondent"
+    ],
+    "D8ScreenHasMarriageBroken": "YES",
+    "D8InferredRespondentGender": "male",
+    "D8ReasonForDivorceEnableAdultery": "YES",
+    "D8LivingArrangementsLiveTogether": "NO",
+    "D8ReasonForDivorceHasMarriage": "YES",
+    "D8RespondentLastName": "Jamed",
+    "D8PetitionerNameDifferentToMarriageCert": "YES",
+    "D8LegalProceedingsDetails": "The legal proceeding details",
+    "BulkListingCaseId": {
+        "CaseReference": "1558862753124996"
+    },
+    "D8ReasonForDivorceAdulteryIsNamed": "NO",
+    "ReceivedAOSfromRespDate": "2018-10-22",
+    "D8ClaimsCostsAppliedForFees": "YES",
+    "D8ReasonForDivorceShowTwoYearsSeparation": "YES",
+    "D8StatementOfTruth": "YES",
+    "DateAndTimeOfHearing": [
+        {
+            "id": "0042963b-ffff-ffff-ffff-4d7a40f10581",
+            "value": {
+                "DateOfHearing": "2020-10-10",
+                "TimeOfHearing": "10:50"
+            }
+        }
+    ],
+    "D8RespondentLivesAtLastAddress": "NO",
+    "D8ReasonForDivorceLimitReasons": "NO",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
+    "D8HelpWithFeesReferenceNumber": "HWF-123-456",
+    "D8ReasonForDivorceShowDesertion": "YES",
+    "D8DerivedRespondentCorrespondenceAddr": "82 Landor Road\nLondon\nSW9 9PE",
+    "D8MarriagePetitionerName": "John Doe",
+    "D8Cohort": "onlineSubmissionPrivateBeta",
+    "D8MarriageIsSameSexCouple": "NO",
+    "D8FinancialOrder": "YES",
+    "D8HelpWithFeesNeedHelp": "YES",
+    "D8DivorceWho": "husband",
+    "D8ScreenHasPrinter": "YES",
+    "D8RespondentFirstName": "Jane",
+    "D8DerivedPetitionerCorrespondenceAddr": "84 Landor Road\nLondon\nSW9 9PE",
+    "D8PetitionerFirstName": "John",
+    "D8MarriageRespondentName": "Jenny Benny",
+    "createdDate": "2018-06-07",
+    "D8RespondentCorrespondenceAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SW9 9PE",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "D8PetitionerNameChangedHow": [
+        "marriageCertificate"
+    ],
+    "D8DerivedPetitionerHomeAddress": "82 Landor Road\nLondon\nSW9 9PE",
+    "D8ScreenHasRespondentAddress": "YES",
+    "D8DivorceCostsClaim": "YES",
+    "D8PetitionerHomeAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SW9 9PE",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "D8ReasonForDivorceShowAdultery": "YES",
+    "D8DerivedStatementOfCase": "My wife is having an affair this week.",
+    "D8JurisdictionConfidentLegal": "YES",
+    "D8RespondentCorrespondenceUseHomeAddress": "Solicitor",
+    "D8FinancialOrderFor": [
+        "petitioner",
+        "children"
+    ],
+    "D8Connections": {
+        "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+        "B": null,
+        "C": "The Respondent is habitually resident in England and Wales",
+        "D": null,
+        "E": null,
+        "F": null,
+        "G": null
+    },
+    "D8PetitionerCorrespondenceAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "AB24 232",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "D8JurisdictionConnection": [
+        "A",
+        "C"
+    ],
+    "D8LegalProceedingsRelated": [
+        "children"
+    ],
+    "D8DerivedLivingArrangementsLastLivedAddr": "Flat A-B\n86 Landor Road\nLondon\nSW9 9PE",
+    "D8PetitionerLastName": "Smith",
+    "D8PetitionerPhoneNumber": "01234567890",
+    "D8PetitionerCorrespondenceUseHomeAddress": "NO",
+    "D8DocumentsGenerated": [
+        {
+            "id": "773beaa6-ffff-ffff-ffff-3efd39954139",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://localhost:5532/documents/5d42f168-ffff-ffff-ffff-62c1f348ab3b",
+                    "document_filename": "respondentAnswers.pdf",
+                    "document_binary_url": "http://localhost:5532/documents/5d42f168-ffff-ffff-ffff-62c1f348ab3b/binary"
+                },
+                "DocumentType": "respondentAnswers",
+                "DocumentComment": null,
+                "DocumentFileName": "respondentAnswers",
+                "DocumentDateAdded": null,
+                "DocumentEmailContent": null
+            }
+        }
+    ],
+    "ReceivedAOSfromResp": "YES",
+    "D8DerivedRespondentCurrentName": "Jane Jamed",
+    "DNApplicationSubmittedDate": "2019-05-26",
+    "D8HelpWithFeesAppliedForFees": "YES",
+    "D8ReasonForDivorceBehaviourDetails": "My wife is having an affair this week.",
+    "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
+    "D8DivorceUnit": "serviceCentre",
+    "D8LivingArrangementsLastLivedTogether": "NO",
+    "D8ReasonForDivorceShowFiveYearsSeparatio": "YES",
+    "D8MarriageDate": "2001-02-02",
+    "D8caseReference": "LV17D80100",
+    "D8JurisdictionRespondentResidence": "YES",
+    "D8MarriageCanDivorce": "YES",
+    "D8ReasonForDivorceShowUnreasonableBehavi": "YES",
+    "D8DerivedRespondentSolicitorDetails": "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "D8JurisdictionPetitionerResidence": "YES",
+    "D8ReasonForDivorceClaimingAdultery": "NO",
+    "D8PetitionerContactDetailsConfidential": "share",
+    "D8DerivedRespondentSolicitorAddr": "90 Landor Road\nLondon\nSW9 9PE",
+    "D8LegalProceedings": "YES",
+    "D8ReasonForDivorce": "unreasonable-behaviour",
+    "D8DerivedPetitionerCurrentFullName": "John Smith",
+    "D8InferredPetitionerGender": "female",
+    "CourtName": "placeholder Court",
+    "CostsClaimGranted": "YES",
+    "DNApprovalDate": "2000-01-01",
+    "DecreeNisiGrantedDate": "2020-01-01"
+}

--- a/src/test/resources/fixtures/model/ccd/InputCoreCaseDataMap.json
+++ b/src/test/resources/fixtures/model/ccd/InputCoreCaseDataMap.json
@@ -1,0 +1,187 @@
+{
+    "BehaviourStillHappeningDN": null,
+    "D8DerivedRespondentHomeAddress": "88 Landor Road\nLondon\nSW9 9PE",
+    "DivorceCostsOptionDN": null,
+    "D8RespondentHomeAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SS SSS",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "D8ScreenHasMarriageCert": "YES",
+    "BehaviourLivedApartSinceEventDN": null,
+    "DocumentsUploadedDN": [],
+    "D8DivorceClaimFrom": [
+        "respondent"
+    ],
+    "D8ScreenHasMarriageBroken": "YES",
+    "D8InferredRespondentGender": "male",
+    "D8ReasonForDivorceEnableAdultery": "YES",
+    "D8LivingArrangementsLiveTogether": "NO",
+    "AdulteryTimeLivedTogetherDetailsDN": null,
+    "D8ReasonForDivorceHasMarriage": "YES",
+    "AdulteryLifeIntolerable": null,
+    "statementOfTruthDN": null,
+    "D8RespondentLastName": "Jamed",
+    "D8PetitionerNameDifferentToMarriageCert": "YES",
+    "D8LegalProceedingsDetails": "The legal proceeding details",
+    "BulkListingCaseId": {
+        "CaseReference": "1558862753124996"
+    },
+    "D8ReasonForDivorceAdulteryIsNamed": "NO",
+    "ReceivedAOSfromRespDate": "2018-10-22",
+    "D8ClaimsCostsAppliedForFees": "YES",
+    "D8ReasonForDivorceShowTwoYearsSeparation": "YES",
+    "D8StatementOfTruth": "YES",
+    "SeparationTimeLivedTogetherDetailsDN": null,
+    "DateAndTimeOfHearing": [
+        {
+            "id": "0042963b-ffff-ffff-ffff-4d7a40f10581",
+            "value": {
+                "DateOfHearing": "2020-10-10",
+                "TimeOfHearing": "10:50"
+            }
+        }
+    ],
+    "D8RespondentLivesAtLastAddress": "NO",
+    "D8ReasonForDivorceLimitReasons": "NO",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
+    "D8HelpWithFeesReferenceNumber": "HWF-123-456",
+    "AdulteryLivedApartSinceEventDN": null,
+    "D8ReasonForDivorceShowDesertion": "YES",
+    "D8DerivedRespondentCorrespondenceAddr": "82 Landor Road\nLondon\nSW9 9PE",
+    "D8MarriagePetitionerName": "John Doe",
+    "D8Cohort": "onlineSubmissionPrivateBeta",
+    "D8MarriageIsSameSexCouple": "NO",
+    "D8FinancialOrder": "YES",
+    "D8HelpWithFeesNeedHelp": "YES",
+    "D8DivorceWho": "husband",
+    "D8ScreenHasPrinter": "YES",
+    "AdulteryDateFoundOut": null,
+    "D8RespondentFirstName": "Jane",
+    "D8DerivedPetitionerCorrespondenceAddr": "84 Landor Road\nLondon\nSW9 9PE",
+    "D8PetitionerFirstName": "John",
+    "D8MarriageRespondentName": "Jenny Benny",
+    "createdDate": "2018-06-07",
+    "D8RespondentCorrespondenceAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SW9 9PE",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "AlternativeRespCorrAddress": null,
+    "D8PetitionerNameChangedHow": [
+        "marriageCertificate"
+    ],
+    "D8DerivedPetitionerHomeAddress": "82 Landor Road\nLondon\nSW9 9PE",
+    "D8ScreenHasRespondentAddress": "YES",
+    "DesertionTimeLivedTogetherDetailsDN": null,
+    "D8DivorceCostsClaim": "YES",
+    "D8PetitionerHomeAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "SW9 9PE",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "DNApplyForDecreeNisi": null,
+    "D8ReasonForDivorceShowAdultery": "YES",
+    "D8DerivedStatementOfCase": "My wife is having an affair this week.",
+    "D8JurisdictionConfidentLegal": "YES",
+    "D8RespondentCorrespondenceUseHomeAddress": "Solicitor",
+    "D8FinancialOrderFor": [
+        "petitioner",
+        "children"
+    ],
+    "D8Connections": {
+        "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+        "B": null,
+        "C": "The Respondent is habitually resident in England and Wales",
+        "D": null,
+        "E": null,
+        "F": null,
+        "G": null
+    },
+    "D8PetitionerCorrespondenceAddress": {
+        "County": null,
+        "Country": null,
+        "PostCode": "AB24 232",
+        "PostTown": null,
+        "AddressLine1": null,
+        "AddressLine2": null,
+        "AddressLine3": null
+    },
+    "BehaviourTimeLivedTogetherDetailsDN": null,
+    "D8JurisdictionConnection": [
+        "A",
+        "C"
+    ],
+    "D8LegalProceedingsRelated": [
+        "children"
+    ],
+    "D8DerivedLivingArrangementsLastLivedAddr": "Flat A-B\n86 Landor Road\nLondon\nSW9 9PE",
+    "SeparationLivedApartSinceEventDN": null,
+    "D8PetitionerLastName": "Smith",
+    "D8PetitionerPhoneNumber": "01234567890",
+    "D8PetitionerCorrespondenceUseHomeAddress": "NO",
+    "D8DocumentsGenerated": [
+        {
+            "id": "773beaa6-ffff-ffff-ffff-3efd39954139",
+            "value": {
+                "DocumentLink": {
+                    "document_url": "http://localhost:5532/documents/5d42f168-ffff-ffff-ffff-62c1f348ab3b",
+                    "document_filename": "respondentAnswers.pdf",
+                    "document_binary_url": "http://localhost:5532/documents/5d42f168-ffff-ffff-ffff-62c1f348ab3b/binary"
+                },
+                "DocumentType": "respondentAnswers",
+                "DocumentComment": null,
+                "DocumentFileName": "respondentAnswers",
+                "DocumentDateAdded": null,
+                "DocumentEmailContent": null
+            }
+        }
+    ],
+    "ReceivedAOSfromResp": "YES",
+    "D8DerivedRespondentCurrentName": "Jane Jamed",
+    "DNApplicationSubmittedDate": "2019-05-26",
+    "D8HelpWithFeesAppliedForFees": "YES",
+    "D8ReasonForDivorceBehaviourDetails": "My wife is having an affair this week.",
+    "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
+    "D8DivorceUnit": "serviceCentre",
+    "D8LivingArrangementsLastLivedTogether": "NO",
+    "D8ReasonForDivorceShowFiveYearsSeparatio": "YES",
+    "D8MarriageDate": "2001-02-02",
+    "D8caseReference": "LV17D80100",
+    "PetitionChangedDetailsDN": null,
+    "D8JurisdictionRespondentResidence": "YES",
+    "D8MarriageCanDivorce": "YES",
+    "BehaviourMostRecentIncidentDateDN": null,
+    "D8ReasonForDivorceShowUnreasonableBehavi": "YES",
+    "D8DerivedRespondentSolicitorDetails": "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "PetitionChangedYesNoDN": null,
+    "ConfirmPetitionDN": null,
+    "D8JurisdictionPetitionerResidence": "YES",
+    "D8ReasonForDivorceClaimingAdultery": "NO",
+    "DesertionLivedApartSinceEventDN": null,
+    "D8PetitionerContactDetailsConfidential": "share",
+    "D8DerivedRespondentSolicitorAddr": "90 Landor Road\nLondon\nSW9 9PE",
+    "CostsDifferentDetails": null,
+    "D8LegalProceedings": "YES",
+    "D8ReasonForDivorce": "unreasonable-behaviour",
+    "D8DerivedPetitionerCurrentFullName": "John Smith",
+    "D8InferredPetitionerGender": "female",
+    "CourtName": "placeholder Court",
+    "CostsClaimGranted": "YES",
+    "DNApprovalDate": "2000-01-01",
+    "DecreeNisiGrantedDate": "2020-01-01",
+    "ExtraUnmappedField": "unmapped",
+    "AnotherUnmappedField": "should be dropped"
+}


### PR DESCRIPTION
This fixes the wrong model format for bulkListingCaseId.

Unit test for earlier merge of PR #141 

This ensures that if a model property is removed from CoreCaseData, it'll fail the unit test if no changes are made to the JSON. This is because CFS will primarily be taking in JSON requests from Case Orchestration Service that have been built as a Map.