### PR TITLE
DIV-5057: OWASP upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.5.RELEASE'
     id 'com.jfrog.bintray' version '1.8.0'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '4.0.2'
+    id 'org.owasp.dependencycheck' version '5.0.0'
     id 'org.sonarqube' version '2.7'
     id 'org.springframework.boot' version '2.1.2.RELEASE'
     id 'pmd'
@@ -89,7 +89,7 @@ distributions {
     }
 }
 
-checkstyle.toolVersion = '7.2'
+checkstyle.toolVersion = '8.21'
 checkstyle.configFile = new File(rootDir, "checkstyle.xml")
 
 // make build fail on Checkstyle issues (https://github.com/gradle/gradle/issues/881)
@@ -132,7 +132,7 @@ def versions = [
     mapstruct: '1.2.0.Final',
     orgSpringframework: '5.1.4.RELEASE',
     pitest: '1.3.2',
-    puppyCrawl: '7.6',
+    puppyCrawl: '8.21',
     reformHealth: '0.0.3',
     reformPropertiesVolume: '0.0.4',
     reformsJavaLogging: '4.0.1',

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -54,9 +54,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/CaseFormatterServiceApplicationTests.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/CaseFormatterServiceApplicationTests.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice;
 
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/AddDocumentsITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/functionaltest/AddDocumentsITest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.functionaltest;
 
-import com.github.tomakehurst.wiremock.common.Json;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,14 +12,11 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceApplication;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestUtil;
-
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/management/monitoring/health/WebServiceHealthCheckUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/management/monitoring/health/WebServiceHealthCheckUTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.caseformatterservice.management.monitoring.health;
 
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;


### PR DESCRIPTION
# Description

- OWASP upgraded to v5, fixed arising vulnerabilities in swagger and elasticsearch
- Checkstyle upgraded to 8.21 with an accompanying modification to the `checkstyle.xml` file

Fixes # [DIV-5057](https://tools.hmcts.net/jira/browse/DIV-5057)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules