### PR TITLE
Don't extend DN with DA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-public class DnCaseData extends DaCaseData {
+public class DnCaseData {
 
     @JsonProperty("DNApplicationSubmittedDate")
     private String dnApplicationSubmittedDate;


### PR DESCRIPTION
# Description

When formatting DN to CCD, when DN is extending DA, it is setting those DA fields to null and passing it to CCD.
However the DA fields are not yet in Production config, so an No Field Found error is thrown.
The DA update is standalone right now, and does not require mapping from CCD to Divorce, so there isn't a requirement for it to be part of the main CoreCaseData model, so the quickest fix to resolve Production issues is to remove the inheritance.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
