### PR TITLE
Add DN Rejection Fields for CCD to Divorce Mapping

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/controller/CaseFormatterController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/controller/CaseFormatterController.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.AosCase
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DaCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnRefusalCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.documentupdate.DocumentUpdateRequest;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.service.CaseFormatterService;
@@ -120,7 +121,7 @@ public class CaseFormatterController {
         @ApiResponse(code = 200, message = "Case transformed into DN Clarification format", response = DnCaseData.class),
         }
     )
-    public ResponseEntity<DnCaseData> getDnClarificationCaseData(
+    public ResponseEntity<DnRefusalCaseData> getDnClarificationCaseData(
         @RequestBody @ApiParam(value = "Divorce CCD and Session data", required = true) DivorceCaseWrapper divorceCaseWrapper) {
         return ResponseEntity.ok(caseFormatterService.getDnClarificationCaseData(divorceCaseWrapper));
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
@@ -89,7 +89,7 @@ public class DnCaseData {
     @JsonProperty("DesertionAskedToResumeDNDetails")
     private String desertionAskedToResumeDNDetails;
 
-    // These three JsonInclude 
+    // These three JsonInclude are ignored for now until DN Refusal Config is in Production
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("DnClarificationResponse")
     private List<CollectionMember<String>> dnClarificationResponse;
@@ -110,6 +110,18 @@ public class DnCaseData {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("RefusalClarificationAdditionalInfo")
     private String refusalClarificationAdditionalInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalRejectionReason")
+    private List<String> refusalRejectionReason;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalRejectionAdditionalInfo")
+    private String refusalRejectionAdditionalInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalAdminErrorInfo")
+    private String refusalAdminErrorInfo;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("DnOutcomeCase")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnCaseData.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-public class DnCaseData {
+@EqualsAndHashCode(callSuper = true)
+public class DnCaseData extends DnRefusalCaseData {
 
     @JsonProperty("DNApplicationSubmittedDate")
     private String dnApplicationSubmittedDate;
@@ -88,42 +90,4 @@ public class DnCaseData {
 
     @JsonProperty("DesertionAskedToResumeDNDetails")
     private String desertionAskedToResumeDNDetails;
-
-    // These three JsonInclude are ignored for now until DN Refusal Config is in Production
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("DnClarificationResponse")
-    private List<CollectionMember<String>> dnClarificationResponse;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("DnClarificationUploadDocuments")
-    private List<CollectionMember<String>> dnClarificationUploadDocuments;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("DocumentsUploadedDnClarification")
-    private List<CollectionMember<Document>> documentsUploadedDnClarification;
-
-    // Caseworker only fields so frontend submission does not modify these
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("RefusalClarificationReason")
-    private List<String> refusalClarificationReason;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("RefusalClarificationAdditionalInfo")
-    private String refusalClarificationAdditionalInfo;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("RefusalRejectionReason")
-    private List<String> refusalRejectionReason;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("RefusalRejectionAdditionalInfo")
-    private String refusalRejectionAdditionalInfo;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("RefusalAdminErrorInfo")
-    private String refusalAdminErrorInfo;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("DnOutcomeCase")
-    private String dnOutcomeCase;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnRefusalCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/DnRefusalCaseData.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class DnRefusalCaseData {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("DnClarificationResponse")
+    private List<CollectionMember<String>> dnClarificationResponse;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("DnClarificationUploadDocuments")
+    private List<CollectionMember<String>> dnClarificationUploadDocuments;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("DocumentsUploadedDnClarification")
+    private List<CollectionMember<Document>> documentsUploadedDnClarification;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalClarificationReason")
+    private List<String> refusalClarificationReason;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalClarificationAdditionalInfo")
+    private String refusalClarificationAdditionalInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalRejectionReason")
+    private List<String> refusalRejectionReason;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalRejectionAdditionalInfo")
+    private String refusalRejectionAdditionalInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("RefusalAdminErrorInfo")
+    private String refusalAdminErrorInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("DnOutcomeCase")
+    private String dnOutcomeCase;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -519,8 +519,17 @@ public class DivorceSession {
     @ApiModelProperty("Reason for why clarification is needed.")
     private List<String> refusalClarificationReason;
 
-    @ApiModelProperty("Any additional input by the legal advisor.")
+    @ApiModelProperty("Any additional input by the legal advisor for clarification.")
     private String refusalClarificationAdditionalInfo;
+
+    @ApiModelProperty("Reason for why refusal rejection is needed.")
+    private List<String> refusalRejectionReason;
+
+    @ApiModelProperty("Any additional input by the legal advisor for refusal rejection.")
+    private String refusalRejectionAdditionalInfo;
+
+    @ApiModelProperty("Any additional input by the legal advisor for admin error.")
+    private String refusalAdminErrorInfo;
 
     @ApiModelProperty(value = "Clarification response for the current clarification journey")
     private String clarificationResponse;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/CCDCaseToDivorceMapper.java
@@ -155,6 +155,9 @@ public abstract class CCDCaseToDivorceMapper {
     @Mapping(source = "dateCaseNoLongerEligibleForDA", dateFormat = SIMPLE_DATE_FORMAT, target = "dateCaseNoLongerEligibleForDA")
     @Mapping(source = "refusalClarificationReason", target = "refusalClarificationReason")
     @Mapping(source = "refusalClarificationAdditionalInfo", target = "refusalClarificationAdditionalInfo")
+    @Mapping(source = "refusalRejectionReason", target = "refusalRejectionReason")
+    @Mapping(source = "refusalRejectionAdditionalInfo", target = "refusalRejectionAdditionalInfo")
+    @Mapping(source = "refusalAdminErrorInfo", target = "refusalAdminErrorInfo")
     @Mapping(source = "dnOutcomeCase", target = "dnOutcomeCase")
     public abstract DivorceSession courtCaseDataToDivorceCaseData(CoreCaseData coreCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnClarificationMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/DivorceCaseToDnClarificationMapper.java
@@ -8,7 +8,7 @@ import org.mapstruct.ReportingPolicy;
 
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.DivorceCaseWrapper;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnRefusalCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
@@ -24,11 +24,11 @@ public abstract class DivorceCaseToDnClarificationMapper {
     private static final String DOCUMENT_COMMENT = "Document";
 
     @Mapping(source = "divorceSession.files", target = "documentsUploadedDnClarification")
-    public abstract DnCaseData divorceCaseDataToDnCaseData(DivorceCaseWrapper divorceCaseWrapper);
+    public abstract DnRefusalCaseData divorceCaseDataToDnCaseData(DivorceCaseWrapper divorceCaseWrapper);
 
     @AfterMapping
     protected void mapDnClarificationResponse(DivorceCaseWrapper divorceCaseWrapper,
-                                              @MappingTarget DnCaseData result) {
+                                              @MappingTarget DnRefusalCaseData result) {
 
         List<CollectionMember<String>> clarificationReasons =
             Optional.ofNullable(divorceCaseWrapper.getCaseData().getDnClarificationResponse())
@@ -50,7 +50,7 @@ public abstract class DivorceCaseToDnClarificationMapper {
 
     @AfterMapping
     protected void mapDnClarificationUploadAnyOtherDocuments(DivorceCaseWrapper divorceCaseWrapper,
-                                                             @MappingTarget DnCaseData result) {
+                                                             @MappingTarget DnRefusalCaseData result) {
 
         List<CollectionMember<String>> uploadAnyOtherDocumentsList =
             Optional.ofNullable(divorceCaseWrapper.getCaseData().getDnClarificationUploadDocuments())
@@ -72,7 +72,7 @@ public abstract class DivorceCaseToDnClarificationMapper {
 
     @AfterMapping
     protected void mapDocumentsUploadedDnClarification(DivorceCaseWrapper divorceCaseWrapper,
-                                                       @MappingTarget DnCaseData result) {
+                                                       @MappingTarget DnRefusalCaseData result) {
 
         List<CollectionMember<Document>> clarificationDocuments =
             Optional.ofNullable(divorceCaseWrapper.getCaseData().getDocumentsUploadedDnClarification())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/CaseFormatterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/CaseFormatterService.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.AosCase
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DaCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnRefusalCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.documentupdate.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
 
@@ -27,7 +28,7 @@ public interface CaseFormatterService {
 
     DnCaseData getDnCaseData(DivorceSession divorceSession);
 
-    DnCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper);
+    DnRefusalCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper);
 
     DaCaseData getDaCaseData(DivorceSession divorceSession);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/service/impl/CaseFormatterServiceImpl.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Collect
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DaCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnRefusalCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.documentupdate.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
@@ -144,7 +145,7 @@ public class CaseFormatterServiceImpl implements CaseFormatterService {
     }
 
     @Override
-    public DnCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper) {
+    public DnRefusalCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper) {
         return divorceCaseToDnClarificationMapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DecreeNisiClarificationMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/ccdtodivorceformat/DecreeNisiClarificationMapperUTest.java
@@ -30,13 +30,13 @@ public class DecreeNisiClarificationMapperUTest {
 
         CoreCaseData coreCaseData = ObjectMapperTestUtil
             .retrieveFileContentsAsObject(
-                "fixtures/ccdtodivorcemapping/ccd/dn-clarification.json",
+                "fixtures/ccdtodivorcemapping/ccd/dn-refusal.json",
                 CoreCaseData.class
             );
 
         DivorceSession expectedDivorceSession = ObjectMapperTestUtil
             .retrieveFileContentsAsObject(
-                "fixtures/ccdtodivorcemapping/divorce/dn-clarification.json",
+                "fixtures/ccdtodivorcemapping/divorce/dn-refusal.json",
                 DivorceSession.class
             );
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/caseformatterservice/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.CaseFormatterServiceAppl
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.DivorceCaseWrapper;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.CoreCaseData;
-import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DnRefusalCaseData;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.ccd.DocumentLink;
 import uk.gov.hmcts.reform.divorce.caseformatterservice.domain.model.usersession.DivorceSession;
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.divorce.caseformatterservice.mapper.ObjectMapperTestU
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,8 +34,8 @@ public class DivorceCaseToDnClarificationMapperUTest {
     public void shouldMapDivorceSessionFieldsToDnCaseData() throws Exception {
         CoreCaseData coreCaseData = new CoreCaseData();
 
-        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
-            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification.json", DnCaseData.class);
+        DnRefusalCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification.json", DnRefusalCaseData.class);
 
         DivorceSession divorceSession = ObjectMapperTestUtil
             .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-clarification.json",
@@ -44,7 +43,7 @@ public class DivorceCaseToDnClarificationMapperUTest {
 
         DivorceCaseWrapper divorceCaseWrapper = new DivorceCaseWrapper(coreCaseData, divorceSession);
 
-        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
+        DnRefusalCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
 
         assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
     }
@@ -80,8 +79,8 @@ public class DivorceCaseToDnClarificationMapperUTest {
         coreCaseData.setDnClarificationUploadDocuments(new ArrayList<>(Arrays.asList(uploadAnyOtherDocuments)));
         coreCaseData.setDocumentsUploadedDnClarification(existingDocuments);
 
-        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
-            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json", DnCaseData.class);
+        DnRefusalCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json", DnRefusalCaseData.class);
 
         DivorceSession divorceSession = ObjectMapperTestUtil
             .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-clarification-existing-data.json",
@@ -89,7 +88,7 @@ public class DivorceCaseToDnClarificationMapperUTest {
 
         DivorceCaseWrapper divorceCaseWrapper = new DivorceCaseWrapper(coreCaseData, divorceSession);
 
-        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
+        DnRefusalCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
 
         assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
     }
@@ -101,9 +100,9 @@ public class DivorceCaseToDnClarificationMapperUTest {
 
         DivorceCaseWrapper divorceCaseWrapper = new DivorceCaseWrapper(coreCaseData, divorceSession);
 
-        DnCaseData expectedDnCaseData = new DnCaseData();
+        DnRefusalCaseData expectedDnCaseData = new DnRefusalCaseData();
 
-        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
+        DnRefusalCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
 
         assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
     }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-clarification.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-clarification.json
@@ -1,7 +1,0 @@
-{
-    "RefusalClarificationReason": [
-        "noJurisdiction",
-        "other"
-    ],
-    "RefusalClarificationAdditionalInfo": "The petitioner needs to provide more information."
-}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-refusal.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-refusal.json
@@ -1,0 +1,13 @@
+{
+    "RefusalClarificationReason": [
+        "jurisdictionDetails",
+        "other"
+    ],
+    "RefusalClarificationAdditionalInfo": "The petitioner needs to provide more information.",
+    "RefusalRejectionReason": [
+        "noJurisdiction",
+        "other"
+    ],
+    "RefusalRejectionAdditionalInfo": "The petitioner needs to provide a lot more information.",
+    "RefusalAdminErrorInfo": "The petitioner needs to provide the admin more information."
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/dn-refusal.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/dn-refusal.json
@@ -1,9 +1,15 @@
 {
     "refusalClarificationReason": [
-        "noJurisdiction",
+        "jurisdictionDetails",
         "other"
     ],
     "refusalClarificationAdditionalInfo": "The petitioner needs to provide more information.",
+    "refusalRejectionReason": [
+        "noJurisdiction",
+        "other"
+    ],
+    "refusalRejectionAdditionalInfo": "The petitioner needs to provide a lot more information.",
+    "refusalAdminErrorInfo": "The petitioner needs to provide the admin more information.",
     "court": {
         "eastMidlands": {
             "divorceCentre": "East Midlands Regional Divorce Centre",


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-5784

Allows Legal Advisor populated DN Rejection fields to be passed back to frontend.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
