### PR TITLE
DIV-6230: Adding Service Application fields to divorce and AOS session so it can be used by frontends

### DIFF
--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -26,5 +26,7 @@
     "D8RespondentSolicitorEmail": "solicitor@localhost.local",
     "D8RespondentSolicitorPhone": "2222222222",
     "respondentSolicitorReference": "1234",
-    "D8DerivedRespondentSolicitorAddr": "90 Landor Road\nLondon\nSW9 9PE"
+    "D8DerivedRespondentSolicitorAddr": "90 Landor Road\nLondon\nSW9 9PE",
+    "ServiceApplicationType": "deemed",
+    "ServiceApplicationGranted": "Yes"
 }

--- a/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/integrationTest/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -241,5 +241,7 @@
     "respConsiderFinancialSituation" : "YES",
     "respHardshipDefenseResponse" : "NO",
     "respHardshipDescription" : "Some Hardship Description goes here",
-    "permittedDecreeNisiReason" : "0"
+    "permittedDecreeNisiReason" : "0",
+    "serviceApplicationType": "deemed",
+    "serviceApplicationGranted": "Yes"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/ccd/AosCaseData.java
@@ -187,4 +187,10 @@ public class AosCaseData extends DnCaseData {
 
     @JsonProperty("CoRespondentPcqId")
     private String coRespondentPcqId;
+
+    @JsonProperty("ServiceApplicationType")
+    private String serviceApplicationType;
+
+    @JsonProperty("ServiceApplicationGranted")
+    private String serviceApplicationGranted;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/caseformatterservice/domain/model/usersession/DivorceSession.java
@@ -456,6 +456,10 @@ public class DivorceSession {
     private Date receivedAosFromRespDate;
     @ApiModelProperty(value = "Respondent has submitted AOS")
     private String receivedAosFromResp;
+    @ApiModelProperty(value = "Service application type")
+    private String serviceApplicationType;
+    @ApiModelProperty(value = "Service Application Granted")
+    private String serviceApplicationGranted;
 
     @ApiModelProperty(value = "Respondent Protected Characteristics Questions Identifier")
     private String respondentPcqId;

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/aos.json
@@ -229,5 +229,7 @@
     "D8PetitionerConsent" : "YES",
     "PermittedDecreeNisiReason" : "0",
     "RespondentPcqId": "2e23d0fa-6b24-47cb-b402-2a7837821d41",
-    "CoRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a"
+    "CoRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a",
+    "ServiceApplicationType": "deemed",
+    "ServiceApplicationGranted": "Yes"
 }

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/aos.json
@@ -246,5 +246,7 @@
     "permittedDecreeNisiReason" : "0",
     "respContactMethodIsDigital" : true,
     "respondentPcqId": "2e23d0fa-6b24-47cb-b402-2a7837821d41",
-    "coRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a"
+    "coRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a",
+    "serviceApplicationType": "deemed",
+    "serviceApplicationGranted": "Yes"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/aos.json
@@ -28,5 +28,7 @@
     "respondentSolicitorReference": "1234",
     "D8DerivedRespondentSolicitorAddr": "90 Landor Road\nLondon\nSW9 9PE",
     "RespondentPcqId": "2e23d0fa-6b24-47cb-b402-2a7837821d41",
-    "CoRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a"
+    "CoRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a",
+    "ServiceApplicationType": "deemed",
+    "ServiceApplicationGranted": "Yes"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/aos.json
@@ -243,5 +243,7 @@
     "respHardshipDescription" : "Some Hardship Description goes here",
     "permittedDecreeNisiReason" : "0",
     "respondentPcqId": "2e23d0fa-6b24-47cb-b402-2a7837821d41",
-    "coRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a"
+    "coRespondentPcqId": "fb4c2b34-7d2a-444e-8667-da59efae8b1a",
+    "serviceApplicationType": "deemed",
+    "serviceApplicationGranted": "Yes"
 }

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn.json
@@ -277,5 +277,7 @@
             "status" : "OK"
         }
     ],
-    "uploadAnyOtherDocuments" : "Yes"
+    "uploadAnyOtherDocuments" : "Yes",
+    "serviceApplicationType": "deemed",
+    "serviceApplicationGranted": "Yes"
 }


### PR DESCRIPTION

# Description

Adding Service Application fields to divorce and AOS session so it can be used by frontends

Fixes https://tools.hmcts.net/jira/browse/DIV-6230

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
